### PR TITLE
Do not document datetime values as ISO8601

### DIFF
--- a/bin/templates/reference-parts/schema.html
+++ b/bin/templates/reference-parts/schema.html
@@ -8,7 +8,7 @@
 				<span class="type">
 					{{ property.type }}{% if property.format %},
 						{% if property.format == 'date-time' %}
-							datetime (ISO8601)
+							datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 						{% elseif property.format == 'uri' %}
 							uri
 						{% else %}

--- a/reference/comments.md
+++ b/reference/comments.md
@@ -108,7 +108,7 @@
 				<code>date</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -121,7 +121,7 @@
 				<code>date_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>

--- a/reference/media.md
+++ b/reference/media.md
@@ -13,7 +13,7 @@
 				<code>date</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -26,7 +26,7 @@
 				<code>date_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -77,7 +77,7 @@
 				<code>modified</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -91,7 +91,7 @@
 				<code>modified_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>

--- a/reference/page-revisions.md
+++ b/reference/page-revisions.md
@@ -24,7 +24,7 @@
 				<code>date</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -37,7 +37,7 @@
 				<code>date_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -73,7 +73,7 @@
 				<code>modified</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -86,7 +86,7 @@
 				<code>modified_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>

--- a/reference/pages.md
+++ b/reference/pages.md
@@ -13,7 +13,7 @@
 				<code>date</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -26,7 +26,7 @@
 				<code>date_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -77,7 +77,7 @@
 				<code>modified</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -91,7 +91,7 @@
 				<code>modified_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>

--- a/reference/post-revisions.md
+++ b/reference/post-revisions.md
@@ -24,7 +24,7 @@
 				<code>date</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -37,7 +37,7 @@
 				<code>date_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -73,7 +73,7 @@
 				<code>modified</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -86,7 +86,7 @@
 				<code>modified_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>

--- a/reference/posts.md
+++ b/reference/posts.md
@@ -13,7 +13,7 @@
 				<code>date</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -26,7 +26,7 @@
 				<code>date_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -77,7 +77,7 @@
 				<code>modified</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>
@@ -91,7 +91,7 @@
 				<code>modified_gmt</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>

--- a/reference/users.md
+++ b/reference/users.md
@@ -154,7 +154,7 @@
 				<code>registered_date</code><br />
 				<span class="type">
 					string,
-													datetime (ISO8601)
+													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
 			<td>


### PR DESCRIPTION
This matches the current content of e.g. https://developer.wordpress.org/rest-api/reference/posts/:

> <img src="https://user-images.githubusercontent.com/227022/28365294-3e4dc38c-6c88-11e7-8b3b-21f0121ff2a0.png" width="450">

See also https://core.trac.wordpress.org/ticket/41032.