### PR TITLE
Update frequently-asked-questions.md

### DIFF
--- a/using-the-rest-api/frequently-asked-questions.md
+++ b/using-the-rest-api/frequently-asked-questions.md
@@ -14,7 +14,7 @@ You can require authentication for all REST API requests by adding an `is_user_l
 
 ```php
 add_filter( 'rest_authentication_errors', function( $result ) {
-    if ( ! empty( $result ) ) {
+    if ( is_wp_error( $result ) ) {
         return $result;
     }
     if ( ! is_user_logged_in() ) {


### PR DESCRIPTION
Instead of of checking for not empty, we should check for a WP_Error object. This seems more consistent with the code in https://core.trac.wordpress.org/browser/tags/4.9.1/src/wp-includes/rest-api/class-wp-rest-server.php#L320