### PR TITLE
Add section about embedding in internal requests

### DIFF
--- a/using-the-rest-api/frequently-asked-questions.md
+++ b/using-the-rest-api/frequently-asked-questions.md
@@ -36,6 +36,24 @@ $request->set_param( 'per_page', 20 );
 $response = rest_do_request( $request );
 ```
 
+## How do I use the _embed parameter on internal requests?
+This won't work. 
+```php
+$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+$request->set_param( '_embed', 1 );
+$response = rest_do_request( $request );
+```
+
+Mutate the response using [WP_REST_Server::response_to_data](https://developer.wordpress.org/reference/classes/wp_rest_server/).
+```php
+global $wp_rest_server;
+$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+$response = rest_do_request($req);
+$response->set_data( $wp_rest_server->response_to_data( $response, true ) );
+
+return $response;
+```
+
 
 ## What happened to the `?filter=` query parameter?
 

--- a/using-the-rest-api/frequently-asked-questions.md
+++ b/using-the-rest-api/frequently-asked-questions.md
@@ -37,23 +37,23 @@ $response = rest_do_request( $request );
 ```
 
 ## How do I use the _embed parameter on internal requests?
-This won't work. 
+
+Setting the `_embed` param on the request object won't work.
+
 ```php
 $request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 $request->set_param( '_embed', 1 );
 $response = rest_do_request( $request );
 ```
 
-Mutate the response using [WP_REST_Server::response_to_data](https://developer.wordpress.org/reference/classes/wp_rest_server/).
+Instead, manually call the [`WP_REST_Server::response_to_data`](https://developer.wordpress.org/reference/classes/wp_rest_server/) function.
+
 ```php
-global $wp_rest_server;
 $request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-$response = rest_do_request($req);
-$response->set_data( $wp_rest_server->response_to_data( $response, true ) );
-
-return $response;
+$response = rest_do_request( $req );
+$data = rest_get_server()->response_to_data( $response, true );
+var_dump( $data['_embedded'] );
 ```
-
 
 ## What happened to the `?filter=` query parameter?
 


### PR DESCRIPTION
I rely on custom endpoints that utilize internal requests to the REST API in many projects, but I've been unable to get responses with the embedded data until this day. 

For some reason that I do not know

```php
$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
$request->set_param( '_embed', 1 );
$response = rest_do_request( $request );
```

does not work. `/wp/v2/posts?_embed=1` as URL doesn't work either. 

Today I dove into the internals because now I really need the embedded data, and managed to find a working solution, albeit ~a bit~ hacky.

```php
global $wp_rest_server;
$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
$response = rest_do_request($req);
$response->set_data( $wp_rest_server->response_to_data( $response, true ) );

return $response;
```

If the solution I came up with is valid, I'd like to add it to the documentation. And if it isn't, how should it be done? 