### PR TITLE
Added info for accessing REST API when using default permalinks

### DIFF
--- a/index.md
+++ b/index.md
@@ -33,6 +33,8 @@ Each of these concepts play a crucial role in using and understanding the WordPr
 
 A route, in the context of the WordPress REST API, is a URI which can be mapped to different HTTP methods. The mapping of an individual HTTP method to a route is known as an "endpoint". To clarify: If we make a `GET` request to `http://oursite.com/wp-json/`, we will get a JSON response showing us what routes are available, and within each route, what endpoints are available. `/wp-json/` is a route itself and when a `GET` request is made it matches to the endpoint that displays what is known as the index for the WordPress REST API. We will learn how to register our own routes and endpoints in the following sections.
 
+If you get a `404` error when trying to access `http://oursite.com/wp-json/` URL you may try fixing your pretty permalinks. If you are using default permalinks (query params) you can access the API at `?rest_route=/`, for example `http://oursite.com/?rest_route=/`. 
+
 
 ### Requests
 

--- a/index.md
+++ b/index.md
@@ -34,7 +34,7 @@ Each of these concepts play a crucial role in using and understanding the WordPr
 A route, in the context of the WordPress REST API, is a URI which can be mapped to different HTTP methods. The mapping of an individual HTTP method to a route is known as an "endpoint". To clarify: If we make a `GET` request to `http://oursite.com/wp-json/`, we will get a JSON response showing us what routes are available, and within each route, what endpoints are available. `/wp-json/` is a route itself and when a `GET` request is made it matches to the endpoint that displays what is known as the index for the WordPress REST API. We will learn how to register our own routes and endpoints in the following sections.
 
 If you get a `404` error when trying to access `http://oursite.com/wp-json/` URL you may try fixing your pretty permalinks.
-[info] If you're using [non-pretty permalinks](https://codex.wordpress.org/Using_Permalinks), you should pass the REST API route as a query string parameter (with `?rest_route=/`, for example `http://oursite.com/?rest_route=/`). The route `http://oursite.com/wp-json/` in the example above would hence be  `http://oursite.com/?rest_route=/`.[/info]
+[info] If you're using [non-pretty permalinks](https://codex.wordpress.org/Using_Permalinks), you should pass the REST API route as a query string parameter (with `rest_route` parameter). The route `http://oursite.com/wp-json/` in the example above would hence be  `http://oursite.com/?rest_route=/`.[/info]
 
 ### Requests
 


### PR DESCRIPTION
Added info for accessing REST API when using default permalinks (query params) or people get 404 errors with `/wp-json/` routes