### PR TITLE
Fixed some reference headings to make them correct / more relevant

### DIFF
--- a/reference/page-revisions.md
+++ b/reference/page-revisions.md
@@ -161,7 +161,7 @@
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve a Page-revision</h2>
+		<h2>List Page-revisions</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>

--- a/reference/post-revisions.md
+++ b/reference/post-revisions.md
@@ -161,7 +161,7 @@
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve a Post-revision</h2>
+		<h2>List Post-revisions</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>

--- a/reference/post-statuses.md
+++ b/reference/post-statuses.md
@@ -104,7 +104,7 @@
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve a Status</h2>
+		<h2>List Statuses</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>

--- a/reference/post-types.md
+++ b/reference/post-types.md
@@ -128,7 +128,7 @@
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve a Type</h2>
+		<h2>List Types</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>

--- a/reference/settings.md
+++ b/reference/settings.md
@@ -165,7 +165,7 @@
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve a Settings</h2>
+		<h2>List Settings</h2>
 			<p>There are no arguments for this endpoint.</p>
 
 	</div>

--- a/reference/taxonomies.md
+++ b/reference/taxonomies.md
@@ -128,7 +128,7 @@
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve a Taxonomy</h2>
+		<h2>List Taxonomies</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>


### PR DESCRIPTION
For some of the list (GET multiple) endpoints the heading is not correct.
Uses singular instead of plural. May mislead users.