### PR TITLE
Add nonce parameter to example Settings request

### DIFF
--- a/reference/settings.md
+++ b/reference/settings.md
@@ -176,7 +176,7 @@
 
 		<h3>Example Request</h3>
 
-		<code>$ curl http://demo.wp-api.org/wp-json/wp/v2/settings</code>
+		<code>$ curl http://example.org/wp-json/wp/v2/settings?_wpnonce={valid 'wp_rest' nonce for logged in admin user}</code>
 	</div>
 </section>
 <section class="route">


### PR DESCRIPTION
This endpoint requires authorization from a user with `manage_options`, so the previous example would never work.

The domain changed to encourage users to test against their own sites, since they won't have valid nonces for demo.wp-api.org.