### PR TITLE
Document the _fields parameter

### DIFF
--- a/using-the-rest-api.md
+++ b/using-the-rest-api.md
@@ -1,22 +1,22 @@
 # Using the REST API
 
-These articles explore the basic structure of the WordPress REST API.
+These articles explore the basic structure of the WordPress REST API.
 
 [Global Parameters](https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/): learn about the global REST API query parameters that apply to every endpoint
 
 [Pagination](https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/): work with large collections of resources & control how many records you receive from the REST API
 
-[Linking & Embedding](https://developer.wordpress.org/rest-api/using-the-rest-api/linking-and-embedding/): understand how to read and modify connections between different objects, and embed related resources such as author and media data in the REST API's responses
+[Linking & Embedding](https://developer.wordpress.org/rest-api/using-the-rest-api/linking-and-embedding/): understand how to read and modify connections between different objects, and embed related resources such as author and media data in the REST API's responses
 
-[Discovery](https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/): determine what REST API resources a site supports, and where they are located
+[Discovery](https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/): determine what REST API resources a site supports, and where they are located
 
-[Authentication](https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/): authorize your REST API requests so that you can create, update and delete your data
+[Authentication](https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/): authorize your REST API requests so that you can create, update and delete your data
 
 [Frequently Asked Questions](https://developer.wordpress.org/rest-api/using-the-rest-api/frequently-asked-questions/): see some of the most frequent inquiries about the REST API and learn how to solve common problems
 
 
 ## Resources & Utilities
 
-[Backbone.js Client](https://developer.wordpress.org/rest-api/using-the-rest-api/backbone-javascript-client/): interact with the API from within WP-Admin using Backbone models & collections
+[Backbone.js Client](https://developer.wordpress.org/rest-api/using-the-rest-api/backbone-javascript-client/): interact with the API from within WP-Admin using Backbone models & collections
 
-[Client Libraries](https://developer.wordpress.org/rest-api/using-the-rest-api/client-libraries/): utilities in a variety of programming languages that simplify interacting with the API
+[Client Libraries](https://developer.wordpress.org/rest-api/using-the-rest-api/client-libraries/): utilities in a variety of programming languages that simplify interacting with the API

--- a/using-the-rest-api/global-parameters.md
+++ b/using-the-rest-api/global-parameters.md
@@ -2,6 +2,39 @@
 
 The API includes a number of global parameters (also called "meta-parameters") which control how the API handles the request/response handling. These operate at a layer above the actual resources themselves, and are available on all resources.
 
+## `_fields`
+
+A REST resource like a Post contains a large quantity of data: basic information such as content, title, and author ID, but also [registered metadata and fields](https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/), media information, and links to other resources. Your application may not need all of this information on every request.
+
+To instruct WordPress to return only a subset of the fields in a response, you may use the `_fields` query parameter. If for example you are building an archive view and only need the ID, title, permalink, author and excerpt for a collection of posts, you can restrict the response to only those properties with this fields query:
+
+```
+/wp/v2/posts?_fields=author,id,excerpt,title,link
+```
+
+You may alternatively provide that same list using query parameter array syntax instead of a comma-separated list:
+
+```
+/wp/v2/posts?_fields[]=author&_fields[]=id&_fields[]=excerpt&_fields[]=title&_fields[]=link
+```
+
+When `_fields` is provided then WordPress will skip unneeded fields when generating your response object, avoiding potentially expensive internal computation or queries for data you don't need. This also means the JSON object returned from the REST API will be smaller, requiring less time to download and less time to parse on your client device.
+
+Carefully design your queries to pull in only the needed properties from each resource to make your application faster to use and more efficient to run.
+
+As of WordPress 5.3 the `_fields` parameter supports nested properties. This can be useful if you have registered many meta keys, permitting you to request the value for only one of the registered meta properties:
+
+```
+?_fields=meta.one-of-many-keys
+```
+
+Only the meta value with the key `one-of-many-keys` will be returned, and others will be excluded.
+
+You can also request specific deeply-nested properties within a complex meta object:
+
+```
+?_fields=meta.key_name.nested_prop.deeply_nested_prop,meta.key_name.other_nested_prop
+```
 
 ## `_jsonp`
 


### PR DESCRIPTION
It was called out on the make/core blog that _fields was undocumented. This is a huge miss, and this PR adds a basic explanatory section at the top of the global parameters document.