### PR TITLE
Update client-libraries.md

### DIFF
--- a/using-the-rest-api/client-libraries.md
+++ b/using-the-rest-api/client-libraries.md
@@ -13,6 +13,8 @@ The [Backbone.js client](https://developer.wordpress.org/rest-api/backbone-javas
 
 [node-wpapi](http://wp-api.org/node-wpapi) is an isomorphic JavaScript client library for querying or writing to the REST API using an intuitive chaining syntax. It can be used with Node.js or with client-side JavaScript applications.
 
+[wp-headless/fetch](https://github.com/wp-headless/fetch) is another isomorphic JavaScript client library with cross-browser support, multiple transport layers and a tiny package footprint. Perfect for modern module based enviroments such as Webpack or Rollup.
+
 [ember-wordpress](https://github.com/oskarrough/ember-wordpress) provides a connection between Ember Data and the REST API
 
 


### PR DESCRIPTION
We recently release an early version of https://github.com/wp-headless/fetch that is now being used in production. 

It's not an easy decision to fragment the ecosystem when there are other offerings. We believe our approach is significantly different enough to warrant this risk. We did so for the following reasons:

* Long unresolved [browser issues](https://github.com/WP-API/node-wpapi/issues/438)
* Bloated [packages size](https://bundlephobia.com/result?p=wpapi@0.12.1)
* No [tree-shakable](https://webpack.js.org/guides/tree-shaking/) ESM or CJS build available
* Opinionated API that attempts to do more then is needed.
* Lack of automated browser testing and coverage
* + more

wp-headless/fetch will be a valuable option to the community and therefore should be listed. Thanks! :-)