### PR TITLE
Update outdated PHP 5.2 discussion on controller class page

### DIFF
--- a/extending-the-rest-api/controller-classes.md
+++ b/extending-the-rest-api/controller-classes.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-When you register a new REST route you usually need to specify a number of callback methods to specify exactly how a request is fulfilled, how permissions checks are applied, and how the schema for your resource gets generated. While it is possible to declare all of these methods in an ordinary PHP file without any wrapping namespace or class, all functions declared in that manner coexist in the same global scope. If you decide to use a common function name for your endpoint logic like `get_items()` and another plugin (or another endpoint in your own plugin) also registers a function with that same name, PHP will fail with a fatal error because the function `get_items()` is being declared twice.
+To register a new REST route, you must specify a number of callback functions to control endpoint behavior such as how a request is fulfilled, how permissions checks are applied, and how the schema for your resource gets generated. While it is possible to declare all of these methods in an ordinary PHP file without any wrapping namespace or class, all functions declared in that manner coexist in the same global scope. If you decide to use a common function name for your endpoint logic like `get_items()` and another plugin (or another endpoint in your own plugin) also registers a function with that same name, PHP will fail with a fatal error because the function `get_items()` is being declared twice.
 
 You can avoid this issue by naming your callback functions using a unique prefix such as `myplugin_myendpoint_` to avoid any potential conflics:
 
@@ -10,19 +10,14 @@ You can avoid this issue by naming your callback functions using a unique prefix
 function myplugin_myendpoint_register_routes() { /* ... */ }
 function myplugin_myendpoint_get_item() { /* ... */ }
 function myplugin_myendpoint_get_item_schema() { /* ... */ }
-function myplugin_myendpoint_get_item_permissions_check() { /* ... */ }
-function myplugin_myendpoint_get_items() { /* ... */ }
-function myplugin_myendpoint_get_items_permissions_check() { /* ... */ }
-function myplugin_myendpoint_prepare_item_for_response() { /* ... */ }
+// etcetera
 
-add_action( 'rest_api_init', 'myplugin_register_routes' );
+add_action( 'rest_api_init', 'myplugin_myendpoint_register_routes' );
 ```
 
 You may already be familiar with this approach because it is commonly used within theme `functions.php` files. However these prefixes are unnecessarily verbose, and several better options exist to group and encapsulate your endpoint's logic in a more maintainable way.
 
-### Namespaces _vs_ Classes
-
-WordPress currently requires PHP 5.6 or greater. PHP 5.6 supports <a href="https://www.php.net/manual/en/language.namespaces.rationale.php">namespaces</a>, which provide an easy way to encapsulate your endpoint's functionality. By declaring a `namespace` at the top of your endpoint's PHP file, all methods within that namespace will be declared within that namespace and will no longer conflict with global functions. You may then use shorter, more-readable names for your endpoint callbacks:
+WordPress currently requires PHP 5.6 or greater. PHP 5.6 supports <a href="https://www.php.net/manual/en/language.namespaces.rationale.php">namespaces</a>, which provide an easy way to encapsulate your endpoint's functionality. By declaring a `namespace` at the top of your endpoint's PHP file, all methods within that namespace will be declared within that namespace and will no longer conflict with global functions. You may then use shorter, more-readable names for your endpoint callbacks.
 
 ```php
 namespace MyPlugin\API\MyEndpoint;
@@ -30,21 +25,18 @@ namespace MyPlugin\API\MyEndpoint;
 function register_routes() { /* ... */ }
 function get_item() { /* ... */ }
 function get_item_schema() { /* ... */ }
-function get_item_permissions_check() { /* ... */ }
-function get_items() { /* ... */ }
-function get_items_permissions_check() { /* ... */ }
-function prepare_item_for_response() { /* ... */ }
+// and so on
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\\register_routes' );
 ```
 
-Before WordPress required a version of PHP which supported namespaces, it was common to declare these related methods in a controller class. Namespaces and controller classes are both robust, maintainable ways to group your endpoint code, and neither is recommended above the other. You may use the approach that best matches the rest of your plugin's codebase.
+While these shorter function names are simpler to work with, they don't provide any other benefits over declaring global functions. For this reason the core REST API endpoints within WordPress are all implemented using a _controller class_.
 
-The remainder of this page details how to write your own controller class.
+The remainder of this page details how to write your own controller class and explains the advantages of doing so.
 
 ## Controllers
 
-Controllers typically do one thing: receive input, and generate output. For the WordPress REST API our controllers will handle request input as `WP_REST_Request` objects and generate response output as `WP_REST_Response` objects. Let's look at an example controller class:
+A controller receives input (a `WP_REST_Request` object, in the case of the WordPress REST API) and generates response output as `WP_REST_Response` objects. Let's look at an example controller class:
 
 ```php
 class My_REST_Posts_Controller {
@@ -256,43 +248,47 @@ function prefix_register_my_rest_routes() {
 add_action( 'rest_api_init', 'prefix_register_my_rest_routes' );
 ```
 
+## Benefits of Classes
 
-## Overview & The Future
+This class contains all the same components you may have written using simple functions. The structure of a class gives us a convenient way to refer to related methods using the `$this->method_name()` syntax, but unlike a namespace the class also permits us to cache values and share logic.
 
-Controller classes tackle two big problems for us while developing endpoints; lack of namespacing and consistent structures. It is important to note that you should not abuse inheritance of your endpoints. For example: if you wrote a controller class for a posts endpoint, like the above example, and wanted to support custom post types as well, you should **NOT** extend your `My_REST_Posts_Controller` like this: `class My_CPT_REST_Controller extends My_REST_Posts_Controller`.
+In the `get_item_schema ` method, note that we store the generated schema on the class as `$this->schema`. Class properties make it easy to cache these sorts of generated values. The introduction of schema caching in WordPress 5.3 increased the speed of some core REST API collection responses by up to 40%, so you should definitely consider following this pattern in your own controllers.
 
-Instead, you should either create an entirely separate controller class, or make `My_REST_Posts_Controller` handle all available post types. When you start go down the path of inheritance, it is important to understand that if the parent classes ever have to change at any point and your subclasses are dependent on them, you will have a major headache. In most cases, you will want to create a base controller class as either an `interface` or `abstract class`, that each of your endpoint controllers can implement or extend. The `abstract class` approach is in use within the core WordPress REST API endpoints.
+## Class Inheritance & WP_REST_Controller
 
+We've seen above how classes solve the global-function encapsulation issue, and how a class instance can be used to cache complex values to speed up response processing. The other major advantage of classes is the way in which class inheritance lets you share logic between multiple endpoints.
 
-## Extending Internal Classes
+Our example class here did not extend any base class, but within WordPress core all endpoint controllers extend a single `abstract` controller class called `WP_REST_Controller`. Extending this class gives you access to a number of useful methods, including but not limited to:
+
+- [`prepare_response_for_collection()`](https://developer.wordpress.org/reference/classes/wp_rest_controller/prepare_response_for_collection/): Prepare a response for insertion into a collection.
+- [`add_additional_fields_to_object()`](https://developer.wordpress.org/reference/classes/wp_rest_controller/add_additional_fields_to_object/): append any registered REST fields to your prepared response object.
+- [`get_fields_for_response()`](https://developer.wordpress.org/reference/classes/wp_rest_controller/get_fields_for_response/): inspect the `_fields` query parameter to determine which response fields have been requested.
+- [`get_context_param()`](https://developer.wordpress.org/reference/classes/wp_rest_controller/get_context_param/): Retrieve the `context` parameter.
+* [`filter_response_by_context()`](https://developer.wordpress.org/reference/classes/wp_rest_controller/filter_response_by_context/): Filters the response shape based on the provided context parameter.
+- [`get_collection_params()`](https://developer.wordpress.org/reference/classes/wp_rest_controller/get_collection_params/): return a basic set of parameter definitions useful for collection endpoints.
+
+Endpoint-specific methods like `get_item`, `register_routes`, and `update_item_permissions_check` are not fully implemented by the abstract class, and must be defined in your own class.
+
+Visit the [`WP_REST_Controller` class reference page](https://developer.wordpress.org/reference/classes/wp_rest_controller/#methods) for a complete list of this controller's methods.
+
+It is important to note that `WP_REST_Controller` is implemented as an `abstract` class and only contains logic that is clearly needed in multiple classes. Inheritance couples your class to the base class it extends, and poorly-considered inheritance trees can make your endpoints much harder to maintain.
+
+As an example, if you wrote a controller class for a posts endpoint (like the example above) and wanted to support custom post types as well, you should **NOT** extend your `My_REST_Posts_Controller` like this: `class My_CPT_REST_Controller extends My_REST_Posts_Controller`. Instead, you should either create an entirely separate base controller class for the shared logic, or make `My_REST_Posts_Controller` handle all available post types. Endpoint logic is subject to changing business requirements, and you don't want to have to change a number of unrelated controllers every time you update your base posts controller.
+
+In most cases you will want to create a base controller class as either an `interface` or `abstract class` which each of your endpoint controllers can implement or extend, or to extend one of the core WordPress REST classes directly.
+
+## Internal WordPress REST API Classes
 
 The WordPress REST API follows a deliberate design pattern for its internal classes, which may be categorized as either *infrastructure* or *endpoint* classes.
 
-Infrastructure classes support the endpoint classes. They handle the logic for the WordPress REST API without performing any data transformation. Endpoint classes, on the other hand, encapsulate the functional logic necessary to perform CRUD operations on WordPress resources. More specifically, our infrastructure classes include `WP_REST_Server` and `WP_REST_Request`, where our endpoint classes include `WP_REST_Posts_Controller` and `WP_REST_Users_Controller`.
+Endpoint classes encapsulate the functional logic necessary to perform [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operations on WordPress resources. WordPress exposes many REST API endpoints (such as [`WP_REST_Posts_Controller`](https://developer.wordpress.org/reference/classes/wp_rest_controller/)), but as discussed above all endpoints extend from a common base controller class:
 
-Let's dive into what each infrastructure class does:
+* [`WP_REST_Controller`](https://developer.wordpress.org/reference/classes/wp_rest_controller/): The base class for all WordPress core endpoints. This class is designed to represent a consistent pattern for manipulating WordPress resources. When interacting with an endpoint that implements `WP_REST_Controller`, a HTTP client can expect each endpoint to behave in a consistent way.
 
+Infrastructure classes support the endpoint classes. They handle the logic for the WordPress REST API without performing any data transformation. The WordPress REST API implements three key infrastructure classes:
 
-* `WP_REST_Server`: The main controller for the WordPress REST API. Routes are registered to the server within WordPress. When `WP_REST_Server` is called upon to serve a request, it determines which route is to be called, and passes the route callback a `WP_REST_Request` object. `WP_REST_Server` also handles authentication, and can perform request validation and permissions checks.
-* `WP_REST_Request`: An object to represent the nature of the request. This object includes request details like request headers, parameters, and method, as well as the route. It can also perform request validation and sanitization.
-* `WP_REST_Response`: An object to represent the nature of the response. This class extends `WP_HTTP_Response`, which includes headers, body, and status, and provides helper methods like `add_link()` for adding linked media, and `query_navigation_headers()` for getting query navigtion headers.
+* [`WP_REST_Server`](https://developer.wordpress.org/reference/classes/wp_rest_server): The main controller for the WordPress REST API. Routes are registered to the server within WordPress. When `WP_REST_Server` is called upon to serve a request, it determines which route is to be called, and passes the route callback a `WP_REST_Request` object. `WP_REST_Server` also handles authentication, and can perform request validation and permissions checks.
+* [`WP_REST_Request`](https://developer.wordpress.org/reference/classes/wp_rest_request): An object to represent the nature of the request. This object includes request details like request headers, parameters, and method, as well as the route. It can also perform request validation and sanitization.
+* [`WP_REST_Response`](https://developer.wordpress.org/reference/classes/wp_rest_response): An object to represent the nature of the response. This class extends `WP_HTTP_Response`, which includes headers, body, and status, and provides helper methods like `add_link()` for adding linked media, and `query_navigation_headers()` for getting query navigtion headers.
 
-All endpoint classes extend `WP_REST_Controller`. This class is designed to represent a consistent pattern for manipulating WordPress resources. `WP_REST_Controller` implements these methods:
-
-* `register_routes()`: After instantiating the class for the first time, call `register_routes()` to register the resource's routes to the server.
-* `get_items()`: Get a collection of existing entities.
-* `get_item()`: Get an existing entity. If the entity doesn't exist, HTTP error code 404 should be returned. If the requester doesn't have permission to access the entity, a HTTP error code 403 should be returned.
-* `create_item()`: Create a new entity, given a valid `WP_REST_Request`. If creation is successful, a `WP_REST_Response` should be returned with HTTP `status=201` and `location` header to the new resource. If creation errors in some form, the appropriate HTTP error code and message should be returned.
-* `update_item()`: Update an existing entity, given a valid `WP_REST_Request`.
-* `delete_item()`: Delete an existing entity, given a valid `WP_REST_Request`. If deletion errors in some way, the appropriate HTTP error code should be returned.
-* `get_items_permissions_check()`: Before calling the callback, check whether a given request has permissions to a collection of a resource.
-* `get_item_permissions_check()`: Before calling the callback, check whether a given request has permissions to get an individual resource.
-* `create_item_permissions_check()`: Before calling the callback, check whether a given request has permissions to create an individual resource.
-* `update_item_permissions_check()`: Before calling the callback, check whether a given request has permissions to update an individual resource.
-* `delete_item_permissions_check()`: Before calling the callback, check whether a given request has permissions to delete an individual resource.
-* `prepare_item_for_response()`: Format a resource to match how it should appear in the response.
-* `prepare_response_for_collection()`: When using `prepare_item_for_response()` a `WP_REST_Response` is returned. This helper function wraps all of these responses into one collection.
-* `filter_response_by_context()`: Filters the response shape based on the provided context parameter.
-* `get_item_schema()`: Get the resource's schema JSON Schema object.
-
-When interacting with an endpoint that implements `WP_REST_Controller`, a HTTP client can expect each endpoint to behave in a similar way.
+Most types of API-driven application will not require you to extend or interact directly with the infrastructure layer, but if you are implementing your own REST API endpoints your application will likely benefit from one or more endpoint controller classes which extend `WP_REST_Controller`.


### PR DESCRIPTION
Because WordPress now supports 5.6, the note about namespaces on this page is no longer accurate. I've provisionally replaced it with a brief introduction to the code structure problem which classes solve, and a note that namespaces may be used in a similar fashion.

Fixes #79