### PR TITLE
Fix datetime caveat link in schema template

### DIFF
--- a/bin/templates/reference-parts/schema.html
+++ b/bin/templates/reference-parts/schema.html
@@ -8,7 +8,7 @@
 				<span class="type">
 					{{ property.type }}{% if property.format %},
 						{% if property.format == 'date-time' %}
-							datetime ([details](https://core.trac.wordpress.org/ticket/41032))
+							datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
 						{% elseif property.format == 'uri' %}
 							uri
 						{% else %}


### PR DESCRIPTION
Fixes #82, where markdown wasn't being parsed in these html templates