### PR TITLE
Regenerate reference for 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ The reference section is created by parsing the output of a site's schema as ret
 - Create a local WordPress environment (always use the current or Release Candidate version of WordPress) using the local environment tool of your choice.
 - Edit `/etc/hosts` to map the domain `example.com` to the IP of that WordPress instance, and ensure the site is configured to run at `example.com`.
 - Run `composer install` in this project's root directory to install dependencies. 
-- Run `bin/regenerate.php` in this project's root directory to run the asset regeneration script.
+- Run `composer run-script regenerate` in this project's root directory to run the asset regeneration script.
 - Use `git status` and `git diff` to validate that the files were updated as expected.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ This repo contains the source for [documentation for the API](https://developer.
 When creating new files, these must be added to the manifest. Run `bin/generate-manifest.php` to update this.
 
 Removing files also requires regenerating the manifest. After deletion and sync with DevHub, the page also needs to be manually deleted from DevHub.
+
+## Refreshing the Templated API Reference
+
+The reference section is created by parsing the output of a site's schema as retrieved from that site's REST API index route. The current method used to generate this approach is as follows:
+
+- Create a local WordPress environment (always use the current or Release Candidate version of WordPress) using the local environment tool of your choice.
+- Edit `/etc/hosts` to map the domain `example.com` to the IP of that WordPress instance, and ensure the site is configured to run at `example.com`.
+- Run `composer install` in this project's root directory to install dependencies. 
+- Run `bin/regenerate.php` in this project's root directory to run the asset regeneration script.
+- Use `git status` and `git diff` to validate that the files were updated as expected.

--- a/bin/manifest.json
+++ b/bin/manifest.json
@@ -64,6 +64,16 @@
         "parent": "extending-the-rest-api",
         "markdown_source": "https://github.com/WP-API/docs/blob/master/extending-the-rest-api/schema.md"
     },
+    "reference/block-revisions": {
+        "slug": "block-revisions",
+        "parent": "reference",
+        "markdown_source": "https://github.com/WP-API/docs/blob/master/reference/block-revisions.md"
+    },
+    "reference/blocks": {
+        "slug": "blocks",
+        "parent": "reference",
+        "markdown_source": "https://github.com/WP-API/docs/blob/master/reference/blocks.md"
+    },
     "reference/categories": {
         "slug": "categories",
         "parent": "reference",
@@ -143,16 +153,6 @@
         "slug": "users",
         "parent": "reference",
         "markdown_source": "https://github.com/WP-API/docs/blob/master/reference/users.md"
-    },
-    "reference/wp_block-revisions": {
-        "slug": "wp_block-revisions",
-        "parent": "reference",
-        "markdown_source": "https://github.com/WP-API/docs/blob/master/reference/wp_block-revisions.md"
-    },
-    "reference/wp_blocks": {
-        "slug": "wp_blocks",
-        "parent": "reference",
-        "markdown_source": "https://github.com/WP-API/docs/blob/master/reference/wp_blocks.md"
     },
     "using-the-rest-api/authentication": {
         "slug": "authentication",

--- a/bin/regenerate.php
+++ b/bin/regenerate.php
@@ -55,6 +55,9 @@ function add_simple_schemas() {
 		}
 		$key = $plural;
 
+		echo "\n";
+		print_r( $title );
+
 		# overrides
 		switch ( $title ) {
 			case 'attachment':
@@ -62,6 +65,12 @@ function add_simple_schemas() {
 				$title = 'Media Item';
 				$plural = 'media';
 				break;
+			
+			case 'settings':
+				$key = 'settings';
+				$title = 'Site Setting';
+				$plural = 'Site Settings';
+			break;
 
 			case 'status':
 				$plural = 'statuses';
@@ -71,11 +80,28 @@ function add_simple_schemas() {
 			case 'type':
 				$key = 'post-types';
 				break;
+			
+			case 'wp_block':
+				$key = 'block';
+				$title = 'Editor Block';
+				$plural = 'Editor Blocks';
+				break;
+			
+			case 'rendered-block':
+				$key = 'rendered-block';
+				$title = 'Rendered Block';
+				$plural = 'Rendered Blocks';
+				break;
+
+			default:
+				// Convert hyphens to spaces ("kebab-case" to "kebab case").
+				// Remove WP_ prefixes.
+				$title = preg_replace( '/WP_/i', '', implode( ' ', explode( '-', $title ) ) );
 		}
 
 		if ( ! isset( $objects[ $key ] ) ) {
 			$objects[ $key ] = [
-				'name' => $title,
+				'name'   => $title,
 				'plural' => $plural,
 				'routes' => [ $route_nicename => update_route( $route ) ],
 				'schema' => $route['schema'],

--- a/bin/regenerate.php
+++ b/bin/regenerate.php
@@ -1,6 +1,11 @@
 #!/usr/bin/env php
 <?php
 
+namespace WPAPI\Docs\Regenerate;
+
+use Requests;
+use Twig;
+
 require dirname( __DIR__ ) . '/vendor/autoload.php';
 
 // This assumes you have a local WP VM running the latest stable WP, mapped to
@@ -54,9 +59,6 @@ function add_simple_schemas() {
 			$plural = substr( $title, -1 ) === 'y' ? substr( $title, 0, -1 ) . 'ies' : $title . 's';
 		}
 		$key = $plural;
-
-		echo "\n";
-		print_r( $title );
 
 		# overrides
 		switch ( $title ) {
@@ -130,12 +132,11 @@ function twig() {
 		return $twig;
 	}
 
-	$loader = new Twig_Loader_Filesystem( __DIR__ . '/templates' );
+	$loader = new Twig\Loader\FilesystemLoader( __DIR__ . '/templates' );
 
-	$twig = new Twig_Environment( $loader, array(
+	$twig = new Twig\Environment( $loader, [
 	    'cache' => false,
-	    // 'cache' => __DIR__ . '/cache',
-	) );
+	] );
 	return $twig;
 }
 

--- a/bin/regenerate.php
+++ b/bin/regenerate.php
@@ -33,6 +33,13 @@ function update_route( $route ) {
 	return $route;
 }
 
+/**
+ * Ingest a title string and ensure any kebab-casing or wp_-prefixing is removed.
+ */
+function cleanup_name( string $name ) : string {
+	return preg_replace( '/WP_/i', '', implode( ' ', explode( '-', $name ) ) );
+}
+
 function add_simple_schemas() {
 	$objects = [];
 
@@ -68,6 +75,12 @@ function add_simple_schemas() {
 				$plural = 'media';
 				break;
 			
+			case 'rendered-block':
+				$key = 'rendered-blocks';
+				$title = 'Rendered Block';
+				$plural = 'Rendered Blocks';
+				break;
+			
 			case 'settings':
 				$key = 'settings';
 				$title = 'Site Setting';
@@ -84,21 +97,21 @@ function add_simple_schemas() {
 				break;
 			
 			case 'wp_block':
-				$key = 'block';
+				$key = 'blocks';
 				$title = 'Editor Block';
 				$plural = 'Editor Blocks';
 				break;
 			
-			case 'rendered-block':
-				$key = 'rendered-block';
-				$title = 'Rendered Block';
-				$plural = 'Rendered Blocks';
+			case 'wp_block-revision':
+				$key = 'block-revisions';
+				$title = 'Block Revision';
+				$plural = 'Block Revisions';
 				break;
 
 			default:
-				// Convert hyphens to spaces ("kebab-case" to "kebab case").
-				// Remove WP_ prefixes.
-				$title = preg_replace( '/WP_/i', '', implode( ' ', explode( '-', $title ) ) );
+				// Fallback title cleaning logic, to remove kebab-casing, etcetera.
+				$title = cleanup_name( $title );
+				$plural = cleanup_name( $plural );
 		}
 
 		if ( ! isset( $objects[ $key ] ) ) {
@@ -108,6 +121,10 @@ function add_simple_schemas() {
 				'routes' => [ $route_nicename => update_route( $route ) ],
 				'schema' => $route['schema'],
 			];
+			print_r( "$key\n" );
+			if ( $key === 'block-revisions' ) {
+				print_r( array_merge( $objects[ $key ], [ 'routes' => null, 'schema' => null ] ) );
+			}
 		} else {
 			$objects[ $key ]['routes'][ $route_nicename ] = update_route( $route );
 		}

--- a/bin/regenerate.php
+++ b/bin/regenerate.php
@@ -3,6 +3,11 @@
 
 require dirname( __DIR__ ) . '/vendor/autoload.php';
 
+// This assumes you have a local WP VM running the latest stable WP, mapped to
+// use the domain name example.com using /etc/hosts. http://demo.wp-api.org is
+// also available, though may be outdated.
+const SITE_URL = 'http://example.com';
+
 function update_route( $route ) {
 	foreach ( $route['endpoints'] as &$endpoint ) {
 		if ( in_array( 'POST', $endpoint['methods'] ) ) {
@@ -26,7 +31,8 @@ function update_route( $route ) {
 function add_simple_schemas() {
 	$objects = [];
 
-	$response = Requests::get( 'http://demo.wp-api.org/wp-json/?context=help' );
+	$response = Requests::get( SITE_URL . '?rest_route=/&context=help' );
+
 	$parsed_data = json_decode( $response->body, true );
 
 	foreach ( $parsed_data['routes'] as $key => $route ) {
@@ -83,7 +89,7 @@ function add_simple_schemas() {
 }
 
 function add_terms_schema() {
-	$response = Requests::options( 'http://demo.wp-api.org/wp-json/wp/v2/terms/category' );
+	$response = Requests::options( SITE_URL . '?rest_route=/wp/v2/terms/category' );
 	$file = fopen( '_data/terms.json', 'w' );
 	$parsed_data = json_decode( $response->body );
 

--- a/bin/regenerate.php
+++ b/bin/regenerate.php
@@ -121,10 +121,6 @@ function add_simple_schemas() {
 				'routes' => [ $route_nicename => update_route( $route ) ],
 				'schema' => $route['schema'],
 			];
-			print_r( "$key\n" );
-			if ( $key === 'block-revisions' ) {
-				print_r( array_merge( $objects[ $key ], [ 'routes' => null, 'schema' => null ] ) );
-			}
 		} else {
 			$objects[ $key ]['routes'][ $route_nicename ] = update_route( $route );
 		}

--- a/bin/templates/endpoint.md
+++ b/bin/templates/endpoint.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# {{ plural | capitalize }}
+# {{ plural | title }}
 
 <section class="route">
 	<div class="primary">

--- a/bin/templates/endpoint.md
+++ b/bin/templates/endpoint.md
@@ -7,11 +7,6 @@
 	<div class="primary">
 		{{ include('reference-parts/schema.html') }}
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json{{ attribute( routes | first, 'nicename' ) }}</code>
-	</div>
 </section>
 
 <div>

--- a/bin/templates/reference-parts/create-item.html
+++ b/bin/templates/reference-parts/create-item.html
@@ -1,6 +1,6 @@
 <section class="route">
 	<div class="primary">
-		<h2>Create a {{ name | capitalize }}</h2>
+		<h2>Create a {{ name | title }}</h2>
 		{{ include( 'reference-parts/args-list.html', { args: endpoint.args, link: true } ) }}
 	</div>
 	<div class="secondary">

--- a/bin/templates/reference-parts/delete-item.html
+++ b/bin/templates/reference-parts/delete-item.html
@@ -1,6 +1,6 @@
 <section class="route">
 	<div class="primary">
-		<h2>Delete a {{ name | capitalize }}</h2>
+		<h2>Delete a {{ name | title }}</h2>
 		{{ include( 'reference-parts/args-list.html', { args: endpoint.args } ) }}
 	</div>
 	<div class="secondary">

--- a/bin/templates/reference-parts/get-item.html
+++ b/bin/templates/reference-parts/get-item.html
@@ -1,6 +1,6 @@
 <section class="route">
 	<div class="primary">
-		<h2>Retrieve a {{ name | capitalize }}</h2>
+		<h2>Retrieve a {{ name | title }}</h2>
 
 		<h3>Definition & Example Request</h3>
 

--- a/bin/templates/reference-parts/get-item.html
+++ b/bin/templates/reference-parts/get-item.html
@@ -1,15 +1,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a {{ name | capitalize }}</h2>
-		{{ include( 'reference-parts/args-list.html', { args: endpoint.args, link: false } ) }}
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
+
+		<h3>Definition & Example Request</h3>
 
 		<code>GET {{ route.nicename }}</code>
 
-		<h3>Example Request</h3>
+		<p>Query this endpoint to retrieve a specific {{ name }} record.</p>
 
 		<code>$ curl https://example.com/wp-json{{ route.nicename }}</code>
+	</div>
+	<div class="secondary">
+		{{ include( 'reference-parts/args-list.html', { args: endpoint.args, link: false } ) }}
 	</div>
 </section>

--- a/bin/templates/reference-parts/list-item.html
+++ b/bin/templates/reference-parts/list-item.html
@@ -1,9 +1,8 @@
 <section class="route">
 	<div class="primary">
 		<h2>List {{ plural | capitalize }}</h2>
-		{{ include( 'reference-parts/args-list.html', { args: endpoint.args, link: false } ) }}
-	</div>
-	<div class="secondary">
+		<p>Query this endpoint to retrieve a collection of {{ plural }}. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
 		<h3>Definition</h3>
 
 		<code>GET {{ route.nicename }}</code>
@@ -11,5 +10,8 @@
 		<h3>Example Request</h3>
 
 		<code>$ curl https://example.com/wp-json{{ route.nicename }}</code>
+	</div>
+	<div class="secondary">
+		{{ include( 'reference-parts/args-list.html', { args: endpoint.args, link: false } ) }}
 	</div>
 </section>

--- a/bin/templates/reference-parts/list-item.html
+++ b/bin/templates/reference-parts/list-item.html
@@ -1,6 +1,6 @@
 <section class="route">
 	<div class="primary">
-		<h2>List {{ plural | capitalize }}</h2>
+		<h2>List {{ plural | title }}</h2>
 		<p>Query this endpoint to retrieve a collection of {{ plural }}. The response you receive can be controlled and filtered using the URL query parameters below.</p>
 
 		<h3>Definition</h3>

--- a/bin/templates/reference-parts/schema.html
+++ b/bin/templates/reference-parts/schema.html
@@ -1,5 +1,5 @@
 <h2>Schema</h2>
-<p>The schema defines all the fields that exist within a {{ schema.title }} record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
+<p>The schema defines all the fields that exist within a {{ name }} record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 	{% for key, property in schema.properties %}
 		<tr id="schema-{{ key }}">

--- a/bin/templates/reference-parts/schema.html
+++ b/bin/templates/reference-parts/schema.html
@@ -1,5 +1,5 @@
 <h2>Schema</h2>
-<p>The schema defines all the fields that exist for a {{ schema.title }} object.</p>
+<p>The schema defines all the fields that exist within a {{ schema.title }} record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 	{% for key, property in schema.properties %}
 		<tr id="schema-{{ key }}">

--- a/bin/templates/reference-parts/update-item.html
+++ b/bin/templates/reference-parts/update-item.html
@@ -1,6 +1,6 @@
 <section class="route">
 	<div class="primary">
-		<h2>Update a {{ name | capitalize }}</h2>
+		<h2>Update a {{ name | title }}</h2>
 		{{ include( 'reference-parts/args-list.html', { args: endpoint.args, link: true } ) }}
 	</div>
 	<div class="secondary">

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,9 @@
 {
+    "name": "wp-api/docs",
+    "description": "The WordPress REST API Handbook",
     "require": {
         "rmccue/requests": "^1.7",
-        "twig/twig": "~1.0"
+        "twig/twig": "^3.0"
     },
     "scripts": {
         "regenerate": "php bin/regenerate.php"

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,8 @@
     "require": {
         "rmccue/requests": "^1.7",
         "twig/twig": "~1.0"
+    },
+    "scripts": {
+        "regenerate": "php bin/regenerate.php"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7605dcba442ebc58999b2a0d3aaaa7e",
+    "content-hash": "8da4e2a132ea94b591d658439ba2745b",
     "packages": [
         {
             "name": "rmccue/requests",
@@ -56,37 +56,152 @@
             "time": "2016-10-13T00:11:37+00:00"
         },
         {
-            "name": "twig/twig",
-            "version": "v1.34.4",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/twigphp/Twig.git",
-                "reference": "f878bab48edb66ad9c6ed626bf817f60c6c096ee"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/f878bab48edb66ad9c6ed626bf817f60c6c096ee",
-                "reference": "f878bab48edb66ad9c6ed626bf817f60c6c096ee",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
-            "require-dev": {
-                "psr/container": "^1.0",
-                "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~3.3@dev"
+            "suggest": {
+                "ext-ctype": "For best performance"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.34-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
                 },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-03-09T19:04:49+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "3b88ccd180a6b61ebb517aea3b1a8906762a1dc2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3b88ccd180a6b61ebb517aea3b1a8906762a1dc2",
+                "reference": "3b88ccd180a6b61ebb517aea3b1a8906762a1dc2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/phpunit-bridge": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -103,22 +218,21 @@
                     "role": "Lead Developer"
                 },
                 {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
                     "name": "Armin Ronacher",
                     "email": "armin.ronacher@active-4.com",
                     "role": "Project Founder"
-                },
-                {
-                    "name": "Twig Team",
-                    "homepage": "http://twig.sensiolabs.org/contributors",
-                    "role": "Contributors"
                 }
             ],
             "description": "Twig, the flexible, fast, and secure template language for PHP",
-            "homepage": "http://twig.sensiolabs.org",
+            "homepage": "https://twig.symfony.com",
             "keywords": [
                 "templating"
             ],
-            "time": "2017-07-04T13:19:31+00:00"
+            "time": "2020-02-11T15:33:47+00:00"
         }
     ],
     "packages-dev": [],

--- a/reference/block-revisions.md
+++ b/reference/block-revisions.md
@@ -1,12 +1,12 @@
 ---
 ---
 
-# wp_block Revisions
+# Block Revisions
 
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a wp_block-revision object.</p>
+<p>The schema defines all the fields that exist within a Block Revision record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
@@ -155,16 +155,21 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/blocks/&lt;id&gt;/autosaves</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve a wp_block-revision</h2>
+		<h2>Retrieve a Block Revision</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/blocks/&lt;id&gt;/autosaves</code>
+
+		<p>Query this endpoint to retrieve a specific Block Revision record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/blocks/&lt;id&gt;/autosaves</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -190,19 +195,10 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/blocks/&lt;id&gt;/autosaves</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/blocks/&lt;id&gt;/autosaves</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Create a wp_block-revision</h2>
+		<h2>Create a Block Revision</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -289,7 +285,17 @@
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Retrieve a wp_block-revision</h2>
+		<h2>Retrieve a Block Revision</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/blocks/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific Block Revision record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/blocks/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -322,15 +328,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/blocks/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/blocks/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
 	</div>
 </section>
 </div>

--- a/reference/blocks.md
+++ b/reference/blocks.md
@@ -1,18 +1,18 @@
 ---
 ---
 
-# wp_blocks
+# Editor Blocks
 
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a wp_block object.</p>
+<p>The schema defines all the fields that exist within a Editor Block record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-date">
 			<td>
 				<code>date</code><br />
 				<span class="type">
-					string,
+					Array,
 													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
@@ -25,7 +25,7 @@
 			<td>
 				<code>date_gmt</code><br />
 				<span class="type">
-					string,
+					Array,
 													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
@@ -182,16 +182,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/blocks</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
-		<h2>List wp_blocks</h2>
+		<h2>List Editor Blocks</h2>
+		<p>Query this endpoint to retrieve a collection of Editor Blocks. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/blocks</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/blocks</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -322,19 +328,10 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/blocks</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/blocks</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Create a wp_block</h2>
+		<h2>Create a Editor Block</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -413,7 +410,17 @@
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Retrieve a wp_block</h2>
+		<h2>Retrieve a Editor Block</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/blocks/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific Editor Block record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/blocks/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -447,19 +454,10 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/blocks/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/blocks/&lt;id&gt;</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Update a wp_block</h2>
+		<h2>Update a Editor Block</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -550,7 +548,7 @@
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Delete a wp_block</h2>
+		<h2>Delete a Editor Block</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -566,7 +564,7 @@
 											<code>force</code><br />
 									</td>
 				<td>
-											<p>Whether to bypass trash and force deletion.</p>
+											<p>Whether to bypass Trash and force deletion.</p>
 																								</td>
 			</tr>
 			</table>

--- a/reference/categories.md
+++ b/reference/categories.md
@@ -6,7 +6,7 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a category object.</p>
+<p>The schema defines all the fields that exist within a category record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
@@ -117,16 +117,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/categories</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>List Categories</h2>
+		<p>Query this endpoint to retrieve a collection of categories. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/categories</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/categories</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -246,15 +252,6 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/categories</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/categories</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
@@ -316,6 +313,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Category</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/categories/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific category record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/categories/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -340,15 +347,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/categories/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/categories/&lt;id&gt;</code>
 	</div>
 </section>
 <section class="route">

--- a/reference/comments.md
+++ b/reference/comments.md
@@ -6,7 +6,7 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a comment object.</p>
+<p>The schema defines all the fields that exist within a comment record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
@@ -214,16 +214,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/comments</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>List Comments</h2>
+		<p>Query this endpoint to retrieve a collection of comments. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/comments</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/comments</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -413,15 +419,6 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/comments</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/comments</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
@@ -544,6 +541,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Comment</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/comments/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific comment record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/comments/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -576,15 +583,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/comments/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/comments/&lt;id&gt;</code>
 	</div>
 </section>
 <section class="route">
@@ -735,7 +733,7 @@
 											<code>force</code><br />
 									</td>
 				<td>
-											<p>Whether to bypass trash and force deletion.</p>
+											<p>Whether to bypass Trash and force deletion.</p>
 																								</td>
 			</tr>
 					<tr>

--- a/reference/media.md
+++ b/reference/media.md
@@ -6,13 +6,13 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for an attachment object.</p>
+<p>The schema defines all the fields that exist within a Media Item record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-date">
 			<td>
 				<code>date</code><br />
 				<span class="type">
-					string,
+					Array,
 													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
@@ -25,7 +25,7 @@
 			<td>
 				<code>date_gmt</code><br />
 				<span class="type">
-					string,
+					Array,
 													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
@@ -322,19 +322,37 @@
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
+			<tr id="schema-missing_image_sizes">
+			<td>
+				<code>missing_image_sizes</code><br />
+				<span class="type">
+					array				</span>
+			</td>
+			<td>
+				<p>List of the missing image sizes of the attachment.</p>
+									<p class="read-only">Read only</p>
+								<p class="context">Context: <code>edit</code></p>
+							</td>
+		</tr>
 	</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/media</code>
 	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>List Media</h2>
+		<p>Query this endpoint to retrieve a collection of media. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/media</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/media</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -500,7 +518,7 @@
 									</td>
 				<td>
 											<p>Limit result set to attachments of a particular media type.</p>
-																										<p>One of: <code>image</code>, <code>video</code>, <code>audio</code>, <code>application</code></p>
+																										<p>One of: <code>image</code>, <code>video</code>, <code>text</code>, <code>application</code>, <code>audio</code></p>
 									</td>
 			</tr>
 					<tr>
@@ -514,19 +532,10 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/media</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/media</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Create a Media item</h2>
+		<h2>Create a Media Item</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -655,7 +664,17 @@
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Retrieve a Media item</h2>
+		<h2>Retrieve a Media Item</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/media/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific Media Item record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/media/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -681,19 +700,10 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/media/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/media/&lt;id&gt;</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Update a Media item</h2>
+		<h2>Update a Media Item</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -834,7 +844,7 @@
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Delete a Media item</h2>
+		<h2>Delete a Media Item</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -850,7 +860,7 @@
 											<code>force</code><br />
 									</td>
 				<td>
-											<p>Whether to bypass trash and force deletion.</p>
+											<p>Whether to bypass Trash and force deletion.</p>
 																								</td>
 			</tr>
 			</table>

--- a/reference/page-revisions.md
+++ b/reference/page-revisions.md
@@ -6,7 +6,7 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a page-revision object.</p>
+<p>The schema defines all the fields that exist within a page revision record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
@@ -152,16 +152,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/pages/&lt;parent&gt;/revisions</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>List Page Revisions</h2>
+		<p>Query this endpoint to retrieve a collection of page revisions. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/pages/&lt;parent&gt;/revisions</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;parent&gt;/revisions</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -262,19 +268,20 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/pages/&lt;parent&gt;/revisions</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;parent&gt;/revisions</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Page Revision</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/pages/&lt;parent&gt;/revisions/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific page revision record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;parent&gt;/revisions/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -307,15 +314,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/pages/&lt;parent&gt;/revisions/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;parent&gt;/revisions/&lt;id&gt;</code>
 	</div>
 </section>
 <section class="route">
@@ -363,6 +361,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Page Revision</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/pages/&lt;id&gt;/autosaves</code>
+
+		<p>Query this endpoint to retrieve a specific page revision record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;id&gt;/autosaves</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -387,15 +395,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/pages/&lt;id&gt;/autosaves</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;id&gt;/autosaves</code>
 	</div>
 </section>
 <section class="route">
@@ -546,6 +545,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Page Revision</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/pages/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific page revision record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -578,15 +587,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/pages/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
 	</div>
 </section>
 </div>

--- a/reference/pages.md
+++ b/reference/pages.md
@@ -6,13 +6,13 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a page object.</p>
+<p>The schema defines all the fields that exist within a page record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-date">
 			<td>
 				<code>date</code><br />
 				<span class="type">
-					string,
+					Array,
 													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
@@ -25,7 +25,7 @@
 			<td>
 				<code>date_gmt</code><br />
 				<span class="type">
-					string,
+					Array,
 													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
@@ -296,16 +296,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/pages</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>List Pages</h2>
+		<p>Query this endpoint to retrieve a collection of pages. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/pages</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/pages</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -476,15 +482,6 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/pages</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/pages</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
@@ -634,6 +631,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Page</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/pages/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific page record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -666,15 +673,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/pages/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/pages/&lt;id&gt;</code>
 	</div>
 </section>
 <section class="route">
@@ -852,7 +850,7 @@
 											<code>force</code><br />
 									</td>
 				<td>
-											<p>Whether to bypass trash and force deletion.</p>
+											<p>Whether to bypass Trash and force deletion.</p>
 																								</td>
 			</tr>
 			</table>

--- a/reference/post-revisions.md
+++ b/reference/post-revisions.md
@@ -1,12 +1,12 @@
 ---
 ---
 
-# Post-revisions
+# Post Revisions
 
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a post-revision object.</p>
+<p>The schema defines all the fields that exist within a post revision record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
@@ -152,16 +152,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/posts/&lt;parent&gt;/revisions</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
-		<h2>List Post-revisions</h2>
+		<h2>List Post Revisions</h2>
+		<p>Query this endpoint to retrieve a collection of post revisions. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/posts/&lt;parent&gt;/revisions</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;parent&gt;/revisions</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -262,19 +268,20 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/posts/&lt;parent&gt;/revisions</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;parent&gt;/revisions</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Retrieve a Post-revision</h2>
+		<h2>Retrieve a Post Revision</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/posts/&lt;parent&gt;/revisions/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific post revision record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;parent&gt;/revisions/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -308,19 +315,10 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/posts/&lt;parent&gt;/revisions/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;parent&gt;/revisions/&lt;id&gt;</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Delete a Post-revision</h2>
+		<h2>Delete a Post Revision</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -362,7 +360,17 @@
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Retrieve a Post-revision</h2>
+		<h2>Retrieve a Post Revision</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/posts/&lt;id&gt;/autosaves</code>
+
+		<p>Query this endpoint to retrieve a specific post revision record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;id&gt;/autosaves</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -388,19 +396,10 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/posts/&lt;id&gt;/autosaves</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;id&gt;/autosaves</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Create a Post-revision</h2>
+		<h2>Create a Post Revision</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -570,7 +569,17 @@
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Retrieve a Post-revision</h2>
+		<h2>Retrieve a Post Revision</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/posts/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific post revision record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -603,15 +612,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/posts/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;parent&gt;/autosaves/&lt;id&gt;</code>
 	</div>
 </section>
 </div>

--- a/reference/post-statuses.md
+++ b/reference/post-statuses.md
@@ -6,7 +6,7 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a status object.</p>
+<p>The schema defines all the fields that exist within a status record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-name">
 			<td>
@@ -92,19 +92,36 @@
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
+			<tr id="schema-date_floating">
+			<td>
+				<code>date_floating</code><br />
+				<span class="type">
+					boolean				</span>
+			</td>
+			<td>
+				<p>Whether posts of this status may have floating published dates.</p>
+									<p class="read-only">Read only</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+							</td>
+		</tr>
 	</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/statuses</code>
 	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>Retrieve a Status</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/statuses</code>
+
+		<p>Query this endpoint to retrieve a specific status record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/statuses</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -122,19 +139,20 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/statuses</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/statuses</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Status</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/statuses/&lt;status&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific status record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/statuses/&lt;status&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -159,15 +177,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/statuses/&lt;status&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/statuses/&lt;status&gt;</code>
 	</div>
 </section>
 </div>

--- a/reference/post-types.md
+++ b/reference/post-types.md
@@ -6,7 +6,7 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a type object.</p>
+<p>The schema defines all the fields that exist within a type record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-capabilities">
 			<td>
@@ -131,16 +131,21 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/types</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>Retrieve a Type</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/types</code>
+
+		<p>Query this endpoint to retrieve a specific type record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/types</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -158,19 +163,20 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/types</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/types</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Type</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/types/&lt;type&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific type record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/types/&lt;type&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -195,15 +201,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/types/&lt;type&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/types/&lt;type&gt;</code>
 	</div>
 </section>
 </div>

--- a/reference/posts.md
+++ b/reference/posts.md
@@ -6,13 +6,13 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a post object.</p>
+<p>The schema defines all the fields that exist within a post record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-date">
 			<td>
 				<code>date</code><br />
 				<span class="type">
-					string,
+					Array,
 													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
@@ -25,7 +25,7 @@
 			<td>
 				<code>date_gmt</code><br />
 				<span class="type">
-					string,
+					Array,
 													datetime ([details](https://core.trac.wordpress.org/ticket/41032))
 										</span>
 			</td>
@@ -319,16 +319,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/posts</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>List Posts</h2>
+		<p>Query this endpoint to retrieve a collection of posts. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/posts</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/posts</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -474,6 +480,15 @@
 			</tr>
 					<tr>
 				<td>
+											<code>tax_relation</code><br />
+									</td>
+				<td>
+											<p>Limit result set based on relationship between multiple taxonomies.</p>
+																										<p>One of: <code>AND</code>, <code>OR</code></p>
+									</td>
+			</tr>
+					<tr>
+				<td>
 											<code>categories</code><br />
 									</td>
 				<td>
@@ -514,15 +529,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/posts</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/posts</code>
 	</div>
 </section>
 <section class="route">
@@ -690,6 +696,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Post</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/posts/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific post record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -722,15 +738,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/posts/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/posts/&lt;id&gt;</code>
 	</div>
 </section>
 <section class="route">
@@ -926,7 +933,7 @@
 											<code>force</code><br />
 									</td>
 				<td>
-											<p>Whether to bypass trash and force deletion.</p>
+											<p>Whether to bypass Trash and force deletion.</p>
 																								</td>
 			</tr>
 			</table>

--- a/reference/rendered-blocks.md
+++ b/reference/rendered-blocks.md
@@ -1,12 +1,12 @@
 ---
 ---
 
-# Rendered-blocks
+# Rendered Blocks
 
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a rendered-block object.</p>
+<p>The schema defines all the fields that exist within a Rendered Block record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-rendered">
 			<td>
@@ -22,16 +22,21 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/block-renderer/&lt;name&gt;</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve a Rendered-block</h2>
+		<h2>Retrieve a Rendered Block</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/block-renderer/&lt;name&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific Rendered Block record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/block-renderer/&lt;name&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -72,15 +77,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/block-renderer/&lt;name&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/block-renderer/&lt;name&gt;</code>
 	</div>
 </section>
 </div>

--- a/reference/search-results.md
+++ b/reference/search-results.md
@@ -1,12 +1,12 @@
 ---
 ---
 
-# Search-results
+# Search Results
 
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a search-result object.</p>
+<p>The schema defines all the fields that exist within a search result record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
@@ -75,16 +75,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/search</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
-		<h2>List Search-results</h2>
+		<h2>List Search Results</h2>
+		<p>Query this endpoint to retrieve a collection of search results. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/search</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/search</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -154,15 +160,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/search</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/search</code>
 	</div>
 </section>
 </div>

--- a/reference/settings.md
+++ b/reference/settings.md
@@ -1,12 +1,12 @@
 ---
 ---
 
-# Settings
+# Site Settings
 
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a settings object.</p>
+<p>The schema defines all the fields that exist within a Site Setting record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-title">
 			<td>
@@ -27,6 +27,32 @@
 			</td>
 			<td>
 				<p>Site tagline.</p>
+								<p class="context">Context: <code></code></p>
+							</td>
+		</tr>
+			<tr id="schema-url">
+			<td>
+				<code>url</code><br />
+				<span class="type">
+					string,
+													uri
+										</span>
+			</td>
+			<td>
+				<p>Site URL.</p>
+								<p class="context">Context: <code></code></p>
+							</td>
+		</tr>
+			<tr id="schema-email">
+			<td>
+				<code>email</code><br />
+				<span class="type">
+					string,
+													email
+									</span>
+			</td>
+			<td>
+				<p>This address is used for admin purposes, like new user notification.</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
@@ -148,7 +174,7 @@
 					string				</span>
 			</td>
 			<td>
-				<p>Allow people to post comments on new articles.</p>
+				<p>Allow people to submit comments on new posts.</p>
 								<p class="context">Context: <code></code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
@@ -156,32 +182,28 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/settings</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve Site Settings</h2>
-			<p>There are no arguments for this endpoint.</p>
+		<h2>Retrieve a Site Setting</h2>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
+		<h3>Definition & Example Request</h3>
 
 		<code>GET /wp/v2/settings</code>
 
-		<h3>Example Request</h3>
+		<p>Query this endpoint to retrieve a specific Site Setting record.</p>
 
 		<code>$ curl https://example.com/wp-json/wp/v2/settings</code>
+	</div>
+	<div class="secondary">
+			<p>There are no arguments for this endpoint.</p>
+
 	</div>
 </section>
 <section class="route">
 	<div class="primary">
-		<h2>Update Site Settings</h2>
+		<h2>Update a Site Setting</h2>
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -198,6 +220,22 @@
 									</td>
 				<td>
 											<p>Site tagline.</p>
+																								</td>
+			</tr>
+					<tr>
+				<td>
+											<code><a href="#schema-url">url</a></code><br />
+									</td>
+				<td>
+											<p>Site URL.</p>
+																								</td>
+			</tr>
+					<tr>
+				<td>
+											<code><a href="#schema-email">email</a></code><br />
+									</td>
+				<td>
+											<p>This address is used for admin purposes, like new user notification.</p>
 																								</td>
 			</tr>
 					<tr>
@@ -286,7 +324,7 @@
 											<code><a href="#schema-default_comment_status">default_comment_status</a></code><br />
 									</td>
 				<td>
-											<p>Allow people to post comments on new articles.</p>
+											<p>Allow people to submit comments on new posts.</p>
 																										<p>One of: <code>open</code>, <code>closed</code></p>
 									</td>
 			</tr>

--- a/reference/tags.md
+++ b/reference/tags.md
@@ -6,7 +6,7 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a tag object.</p>
+<p>The schema defines all the fields that exist within a tag record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
@@ -106,16 +106,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/tags</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>List Tags</h2>
+		<p>Query this endpoint to retrieve a collection of tags. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/tags</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/tags</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -235,15 +241,6 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/tags</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/tags</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
@@ -297,6 +294,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Tag</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/tags/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific tag record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/tags/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -321,15 +328,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/tags/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/tags/&lt;id&gt;</code>
 	</div>
 </section>
 <section class="route">

--- a/reference/taxonomies.md
+++ b/reference/taxonomies.md
@@ -6,7 +6,7 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a taxonomy object.</p>
+<p>The schema defines all the fields that exist within a taxonomy record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-capabilities">
 			<td>
@@ -131,16 +131,21 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/taxonomies</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>Retrieve a Taxonomy</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/taxonomies</code>
+
+		<p>Query this endpoint to retrieve a specific taxonomy record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/taxonomies</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -166,19 +171,20 @@
 			</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/taxonomies</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/taxonomies</code>
-	</div>
 </section>
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a Taxonomy</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/taxonomies/&lt;taxonomy&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific taxonomy record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/taxonomies/&lt;taxonomy&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -203,15 +209,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/taxonomies/&lt;taxonomy&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/taxonomies/&lt;taxonomy&gt;</code>
 	</div>
 </section>
 </div>

--- a/reference/themes.md
+++ b/reference/themes.md
@@ -6,13 +6,13 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a theme object.</p>
+<p>The schema defines all the fields that exist within a theme record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-theme_supports">
 			<td>
 				<code>theme_supports</code><br />
 				<span class="type">
-					array				</span>
+					object				</span>
 			</td>
 			<td>
 				<p>Features supported by this theme.</p>
@@ -23,16 +23,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/themes</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>List Themes</h2>
+		<p>Query this endpoint to retrieve a collection of themes. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/themes</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/themes</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -86,15 +92,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/themes</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/themes</code>
 	</div>
 </section>
 </div>

--- a/reference/users.md
+++ b/reference/users.md
@@ -6,7 +6,7 @@
 <section class="route">
 	<div class="primary">
 		<h2>Schema</h2>
-<p>The schema defines all the fields that exist for a user object.</p>
+<p>The schema defines all the fields that exist within a user record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
@@ -235,16 +235,22 @@
 	</table>
 
 	</div>
-	<div class="secondary">
-		<h3>Example Request</h3>
-
-		<code>$ curl -X OPTIONS -i https://example.com/wp-json/wp/v2/users</code>
-	</div>
 </section>
 
 <div><section class="route">
 	<div class="primary">
 		<h2>List Users</h2>
+		<p>Query this endpoint to retrieve a collection of users. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/users</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/users</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -364,15 +370,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/users</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/users</code>
 	</div>
 </section>
 <section class="route">
@@ -506,6 +503,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a User</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/users/&lt;id&gt;</code>
+
+		<p>Query this endpoint to retrieve a specific user record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/users/&lt;id&gt;</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -530,15 +537,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/users/&lt;id&gt;</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/users/&lt;id&gt;</code>
 	</div>
 </section>
 <section class="route">
@@ -720,6 +718,16 @@
 <section class="route">
 	<div class="primary">
 		<h2>Retrieve a User</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp/v2/users/me</code>
+
+		<p>Query this endpoint to retrieve a specific user record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/users/me</code>
+	</div>
+	<div class="secondary">
 			<h3>Arguments</h3>
 	<table class="arguments">
 					<tr>
@@ -736,15 +744,6 @@
 			</tr>
 			</table>
 
-	</div>
-	<div class="secondary">
-		<h3>Definition</h3>
-
-		<code>GET /wp/v2/users/me</code>
-
-		<h3>Example Request</h3>
-
-		<code>$ curl https://example.com/wp-json/wp/v2/users/me</code>
 	</div>
 </section>
 <section class="route">


### PR DESCRIPTION
- Regenerate reference for 5.4
- Document how to regenerate the reference
- Add overrides for resource naming to e.g. change wp_block-revisions to "Block Revisions"