### PR TITLE
Update controller-classes.md

### DIFF
--- a/extending-the-rest-api/controller-classes.md
+++ b/extending-the-rest-api/controller-classes.md
@@ -194,9 +194,9 @@ class My_REST_Posts_Controller {
 	/**
 	 * Get our sample schema for a post.
 	 *
-	 * @param WP_REST_Request $request Current request.
+	 * @return array The sample schema for a post
 	 */
-	public function get_item_schema( $request ) {
+	public function get_item_schema() {
 		if ( $this->schema ) {
 			// Since WordPress 5.3, the schema can be cached in the $schema property.
 			return $this->schema;


### PR DESCRIPTION
Removed $request param from get_item_schema() since this function does not actually support parameters when used in the WP_REST_Controller class. Including the param here is misleading since it is not needed, even in this custom controller. If the reader uses this example with the WP_REST_Controller class, an error will occur.