### PR TITLE
Small typo in heading

### DIFF
--- a/reference/taxonomies.md
+++ b/reference/taxonomies.md
@@ -135,13 +135,13 @@
 
 <div><section class="route">
 	<div class="primary">
-		<h2>Retrieve a Taxonomy</h2>
+		<h2>Retrieve Taxonomies</h2>
 
 		<h3>Definition & Example Request</h3>
 
 		<code>GET /wp/v2/taxonomies</code>
 
-		<p>Query this endpoint to retrieve a specific taxonomy record.</p>
+		<p>Query this endpoint to retrieve all available taxonomies.</p>
 
 		<code>$ curl https://example.com/wp-json/wp/v2/taxonomies</code>
 	</div>


### PR DESCRIPTION
Changed the heading, as when retrieving multiple taxonomies, the heading should be "Retrieve Taxonomies" and not "Retrieve Taxonomy".