### PR TITLE
Remove reference to shut down demo site

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -104,5 +104,3 @@ This API reference provides information on the specific endpoints available thro
 ## A Distributed API
 
 Unlike many other REST APIs, the WordPress REST API is distributed and available individually on each site that supports it. This means there is no singular API root or base to contact; instead, we have [a discovery process](https://developer.wordpress.org/rest-api/discovery/) that allows interacting with sites without prior contact. The API also exposes self-documentation at the index endpoint, or via an `OPTIONS` request to any endpoint, allowing human- or machine-discovery of endpoint capabilities.
-
-A [demo installation](https://demo.wp-api.org/) of the API for testing purposes is available at `https://demo.wp-api.org/wp-json/`; this site supports auto-discovery, and provides read-only demo data.


### PR DESCRIPTION
I noticed that the URL is no longer working for the demo site. After looking into it it seems that the site has been shut down https://github.com/humanmade/wp-api-demo/issues/79 for more information. This PR is to remove the paragraph/links to the demo site which is no longer up.