### PR TITLE
Adding PHP client libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore Composer files
+.idea/
 vendor/

--- a/using-the-rest-api/client-libraries.md
+++ b/using-the-rest-api/client-libraries.md
@@ -6,6 +6,11 @@ The API can be used from any application by sending basic HTTP requests; however
 
 [info]To perform authenticated requests from outside of the WordPress admin, themes, or plugins, a separate <a href="https://developer.wordpress.org/rest-api/authentication/#authentication-plugins">authentication plugin</a> is required.[/info]
 
+## PHP
+
+[Requests](https://github.com/WordPress/Requests) for PHP is a humble HTTP request library. While not specifically designed for the WordPress REST API, it is a great tool for interacting with any REST API.
+
+[WordPress-PHP-SDK](https://github.com/madeITBelgium/WordPress-PHP-SDK) is a PHP SDK for the WordPress REST API, which can be installed using [composer](https://getcomposer.org/).
 
 ## JavaScript
 

--- a/using-the-rest-api/client-libraries.md
+++ b/using-the-rest-api/client-libraries.md
@@ -8,7 +8,7 @@ The API can be used from any application by sending basic HTTP requests; however
 
 ## PHP
 
-[Requests](https://github.com/WordPress/Requests) for PHP is a humble HTTP request library. While not specifically designed for the WordPress REST API, it is a great tool for interacting with any REST API.
+[Requests](https://github.com/WordPress/Requests) for PHP is a general purpose HTTP request library. While not specifically designed for the WordPress REST API, it is a great tool for interacting with any HTTP API.
 
 [WordPress-PHP-SDK](https://github.com/madeITBelgium/WordPress-PHP-SDK) is a PHP SDK for the WordPress REST API, which can be installed using [composer](https://getcomposer.org/).
 


### PR DESCRIPTION
Adds two PHP library examples to the Client Libraries page

https://github.com/WordPress/Requests
https://github.com/madeITBelgium/WordPress-PHP-SDK

Fixes #153