### PR TITLE
Add custom taxonomy note in the tags endpoint reference

### DIFF
--- a/reference/tags.md
+++ b/reference/tags.md
@@ -423,3 +423,11 @@
 	</div>
 </section>
 </div>
+<div>
+    <section class="route">
+	    <div class="primary">
+		    <h2>Custom Taxonomies</h2>
+            <p>The <code>tags</code> endpoint only deals with tags/terms in the <code>post_tag</code> taxonomy. To work with terms in a custom taxonomy, read about <a href="../extending-the-rest-api/adding-rest-api-support-for-custom-content-types/#registering-a-custom-taxonomy-with-rest-api-support">registering a custom taxonomy with REST API support</a>.</p>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
Right now it's difficult to find information about working with terms in a custom taxonomy via the REST API. There may be a better place for this, but my hope is that by adding a note to the tags page where developers may naturally look for that information, we can get them to the right documentation faster.