### PR TITLE
[NEW] Add wordpress_client library to the Client Libraries list

### DIFF
--- a/using-the-rest-api/client-libraries.md
+++ b/using-the-rest-api/client-libraries.md
@@ -22,3 +22,6 @@ The [Backbone.js client](https://developer.wordpress.org/rest-api/backbone-javas
 
 ## C# / .NET
 [WordPressPCL](https://github.com/wp-net/WordPressPCL): a full REST API client written in C#.
+
+## Dart / Flutter
+[wordpress_client](https://pub.dev/packages/wordpress_client): A library exposing a fluent api to interact with the wordpress REST API.


### PR DESCRIPTION
wordpress_client is a Dart/Flutter library to interact with the Wordpress REST API. Please let me know if any further changes are required!