### PR TITLE
Move schema field type to right column

### DIFF
--- a/bin/templates/reference-parts/schema.html
+++ b/bin/templates/reference-parts/schema.html
@@ -4,20 +4,20 @@
 	{% for key, property in schema.properties %}
 		<tr id="schema-{{ key }}">
 			<td>
-				<code>{{ key }}</code><br />
-				<span class="type">
-					{{ property.type | join(' or ') }}{% if property.format %},
+				<code>{{ key }}</code>
+				</td>
+				<td>
+					<p>{{ property.description }}</p>
+					<p class="type">
+						JSON data type: {{ property.type | join(' or ') }}{% if property.format %},
 						{% if property.format == 'date-time' %}
-							datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+							Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
 						{% elseif property.format == 'uri' %}
-							uri
+							Format: uri
 						{% else %}
-							{{ property.format }}
+							Format: {{ property.format }}
 					{% endif %}{% endif %}
-				</span>
-			</td>
-			<td>
-				<p>{{ property.description }}</p>
+				</p>
 				{% if property.readonly %}
 					<p class="read-only">Read only</p>
 				{% endif %}

--- a/bin/templates/reference-parts/schema.html
+++ b/bin/templates/reference-parts/schema.html
@@ -5,17 +5,17 @@
 		<tr id="schema-{{ key }}">
 			<td>
 				<code>{{ key }}</code>
-				</td>
-				<td>
-					<p>{{ property.description }}</p>
-					<p class="type">
-						JSON data type: {{ property.type | join(' or ') }}{% if property.format %},
-						{% if property.format == 'date-time' %}
-							Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-						{% elseif property.format == 'uri' %}
-							Format: uri
-						{% else %}
-							Format: {{ property.format }}
+			</td>
+			<td>
+				<p>{{ property.description }}</p>
+				<p class="type">
+					JSON data type: {{ property.type | join(' or ') }}{% if property.format %},
+					{% if property.format == 'date-time' %}
+						Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+					{% elseif property.format == 'uri' %}
+						Format: uri
+					{% else %}
+						Format: {{ property.format }}
 					{% endif %}{% endif %}
 				</p>
 				{% if property.readonly %}

--- a/reference/application-passwords.md
+++ b/reference/application-passwords.md
@@ -10,92 +10,92 @@
 <table class="attributes">
 			<tr id="schema-uuid">
 			<td>
-				<code>uuid</code><br />
-				<span class="type">
-					string,
-													uuid
-									</span>
-			</td>
-			<td>
-				<p>The unique identifier for the application password.</p>
+				<code>uuid</code>
+				</td>
+				<td>
+					<p>The unique identifier for the application password.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uuid
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-app_id">
 			<td>
-				<code>app_id</code><br />
-				<span class="type">
-					string,
-													uuid
-									</span>
-			</td>
-			<td>
-				<p>A UUID provided by the application to uniquely identify it. It is recommended to use an UUID v5 with the URL or DNS namespace.</p>
+				<code>app_id</code>
+				</td>
+				<td>
+					<p>A UUID provided by the application to uniquely identify it. It is recommended to use an UUID v5 with the URL or DNS namespace.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uuid
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The name of the application password.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The name of the application password.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-password">
 			<td>
-				<code>password</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The generated password. Only available after adding an application.</p>
+				<code>password</code>
+				</td>
+				<td>
+					<p>The generated password. Only available after adding an application.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-created">
 			<td>
-				<code>created</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The GMT date the application password was created.</p>
+				<code>created</code>
+				</td>
+				<td>
+					<p>The GMT date the application password was created.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-last_used">
 			<td>
-				<code>last_used</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The GMT date the application password was last used.</p>
+				<code>last_used</code>
+				</td>
+				<td>
+					<p>The GMT date the application password was last used.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-last_ip">
 			<td>
-				<code>last_ip</code><br />
-				<span class="type">
-					string or null,
-													ip
-									</span>
-			</td>
-			<td>
-				<p>The IP address the application password was last used by.</p>
+				<code>last_ip</code>
+				</td>
+				<td>
+					<p>The IP address the application password was last used by.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: ip
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/application-passwords.md
+++ b/reference/application-passwords.md
@@ -11,12 +11,12 @@
 			<tr id="schema-uuid">
 			<td>
 				<code>uuid</code>
-				</td>
-				<td>
-					<p>The unique identifier for the application password.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uuid
+			</td>
+			<td>
+				<p>The unique identifier for the application password.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uuid
 									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
@@ -25,12 +25,12 @@
 			<tr id="schema-app_id">
 			<td>
 				<code>app_id</code>
-				</td>
-				<td>
-					<p>A UUID provided by the application to uniquely identify it. It is recommended to use an UUID v5 with the URL or DNS namespace.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uuid
+			</td>
+			<td>
+				<p>A UUID provided by the application to uniquely identify it. It is recommended to use an UUID v5 with the URL or DNS namespace.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uuid
 									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -38,22 +38,22 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The name of the application password.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The name of the application password.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-password">
 			<td>
 				<code>password</code>
-				</td>
-				<td>
-					<p>The generated password. Only available after adding an application.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The generated password. Only available after adding an application.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -61,13 +61,13 @@
 			<tr id="schema-created">
 			<td>
 				<code>created</code>
-				</td>
-				<td>
-					<p>The GMT date the application password was created.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The GMT date the application password was created.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -75,13 +75,13 @@
 			<tr id="schema-last_used">
 			<td>
 				<code>last_used</code>
-				</td>
-				<td>
-					<p>The GMT date the application password was last used.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The GMT date the application password was last used.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -89,12 +89,12 @@
 			<tr id="schema-last_ip">
 			<td>
 				<code>last_ip</code>
-				</td>
-				<td>
-					<p>The IP address the application password was last used by.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: ip
+			</td>
+			<td>
+				<p>The IP address the application password was last used by.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: ip
 									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>

--- a/reference/block-directory-items.md
+++ b/reference/block-directory-items.md
@@ -10,148 +10,148 @@
 <table class="attributes">
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The block name, in namespace/block-name format.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The block name, in namespace/block-name format.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The block title, in human readable format.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The block title, in human readable format.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A short description of the block, in human readable format.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>A short description of the block, in human readable format.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The block slug.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>The block slug.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rating">
 			<td>
-				<code>rating</code><br />
-				<span class="type">
-					number				</span>
-			</td>
-			<td>
-				<p>The star rating of the block.</p>
+				<code>rating</code>
+				</td>
+				<td>
+					<p>The star rating of the block.</p>
+					<p class="type">
+						JSON data type: number				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rating_count">
 			<td>
-				<code>rating_count</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The number of ratings.</p>
+				<code>rating_count</code>
+				</td>
+				<td>
+					<p>The number of ratings.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-active_installs">
 			<td>
-				<code>active_installs</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The number sites that have activated this block.</p>
+				<code>active_installs</code>
+				</td>
+				<td>
+					<p>The number sites that have activated this block.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_block_rating">
 			<td>
-				<code>author_block_rating</code><br />
-				<span class="type">
-					number				</span>
-			</td>
-			<td>
-				<p>The average rating of blocks published by the same author.</p>
+				<code>author_block_rating</code>
+				</td>
+				<td>
+					<p>The average rating of blocks published by the same author.</p>
+					<p class="type">
+						JSON data type: number				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_block_count">
 			<td>
-				<code>author_block_count</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The number of blocks published by the same author.</p>
+				<code>author_block_count</code>
+				</td>
+				<td>
+					<p>The number of blocks published by the same author.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The WordPress.org username of the block author.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The WordPress.org username of the block author.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-icon">
 			<td>
-				<code>icon</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>The block icon.</p>
+				<code>icon</code>
+				</td>
+				<td>
+					<p>The block icon.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-last_updated">
 			<td>
-				<code>last_updated</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date when the block was last updated.</p>
+				<code>last_updated</code>
+				</td>
+				<td>
+					<p>The date when the block was last updated.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-humanized_updated">
 			<td>
-				<code>humanized_updated</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The date when the block was last updated, in fuzzy human readable format.</p>
+				<code>humanized_updated</code>
+				</td>
+				<td>
+					<p>The date when the block was last updated, in fuzzy human readable format.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>

--- a/reference/block-directory-items.md
+++ b/reference/block-directory-items.md
@@ -11,147 +11,147 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The block name, in namespace/block-name format.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The block name, in namespace/block-name format.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The block title, in human readable format.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The block title, in human readable format.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>A short description of the block, in human readable format.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A short description of the block, in human readable format.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>The block slug.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The block slug.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rating">
 			<td>
 				<code>rating</code>
-				</td>
-				<td>
-					<p>The star rating of the block.</p>
-					<p class="type">
-						JSON data type: number				</p>
+			</td>
+			<td>
+				<p>The star rating of the block.</p>
+				<p class="type">
+					JSON data type: number				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rating_count">
 			<td>
 				<code>rating_count</code>
-				</td>
-				<td>
-					<p>The number of ratings.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The number of ratings.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-active_installs">
 			<td>
 				<code>active_installs</code>
-				</td>
-				<td>
-					<p>The number sites that have activated this block.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The number sites that have activated this block.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_block_rating">
 			<td>
 				<code>author_block_rating</code>
-				</td>
-				<td>
-					<p>The average rating of blocks published by the same author.</p>
-					<p class="type">
-						JSON data type: number				</p>
+			</td>
+			<td>
+				<p>The average rating of blocks published by the same author.</p>
+				<p class="type">
+					JSON data type: number				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_block_count">
 			<td>
 				<code>author_block_count</code>
-				</td>
-				<td>
-					<p>The number of blocks published by the same author.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The number of blocks published by the same author.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The WordPress.org username of the block author.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The WordPress.org username of the block author.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-icon">
 			<td>
 				<code>icon</code>
-				</td>
-				<td>
-					<p>The block icon.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>The block icon.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-last_updated">
 			<td>
 				<code>last_updated</code>
-				</td>
-				<td>
-					<p>The date when the block was last updated.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date when the block was last updated.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>
 			<tr id="schema-humanized_updated">
 			<td>
 				<code>humanized_updated</code>
-				</td>
-				<td>
-					<p>The date when the block was last updated, in fuzzy human readable format.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The date when the block was last updated, in fuzzy human readable format.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code></p>
 							</td>
 		</tr>

--- a/reference/block-pattern-categories.md
+++ b/reference/block-pattern-categories.md
@@ -10,36 +10,36 @@
 <table class="attributes">
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The category name.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The category name.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-label">
 			<td>
-				<code>label</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The category label, in human readable format.</p>
+				<code>label</code>
+				</td>
+				<td>
+					<p>The category label, in human readable format.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The category description, in human readable format.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>The category description, in human readable format.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>

--- a/reference/block-pattern-categories.md
+++ b/reference/block-pattern-categories.md
@@ -11,11 +11,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The category name.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The category name.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-label">
 			<td>
 				<code>label</code>
-				</td>
-				<td>
-					<p>The category label, in human readable format.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The category label, in human readable format.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>The category description, in human readable format.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The category description, in human readable format.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>

--- a/reference/block-patterns.md
+++ b/reference/block-patterns.md
@@ -11,11 +11,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The pattern name.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The pattern name.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The pattern title, in human readable format.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The pattern title, in human readable format.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The pattern content.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The pattern content.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -47,11 +47,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>The pattern detailed description.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The pattern detailed description.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -59,11 +59,11 @@
 			<tr id="schema-viewport_width">
 			<td>
 				<code>viewport_width</code>
-				</td>
-				<td>
-					<p>The pattern viewport width for inserter preview.</p>
-					<p class="type">
-						JSON data type: number				</p>
+			</td>
+			<td>
+				<p>The pattern viewport width for inserter preview.</p>
+				<p class="type">
+					JSON data type: number				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -71,11 +71,11 @@
 			<tr id="schema-inserter">
 			<td>
 				<code>inserter</code>
-				</td>
-				<td>
-					<p>Determines whether the pattern is visible in inserter.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Determines whether the pattern is visible in inserter.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -83,11 +83,11 @@
 			<tr id="schema-categories">
 			<td>
 				<code>categories</code>
-				</td>
-				<td>
-					<p>The pattern category slugs.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>The pattern category slugs.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -95,11 +95,11 @@
 			<tr id="schema-keywords">
 			<td>
 				<code>keywords</code>
-				</td>
-				<td>
-					<p>The pattern keywords.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>The pattern keywords.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -107,11 +107,11 @@
 			<tr id="schema-block_types">
 			<td>
 				<code>block_types</code>
-				</td>
-				<td>
-					<p>Block types that the pattern is intended to be used with.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Block types that the pattern is intended to be used with.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -119,11 +119,11 @@
 			<tr id="schema-post_types">
 			<td>
 				<code>post_types</code>
-				</td>
-				<td>
-					<p>An array of post types that the pattern is restricted to be used with.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>An array of post types that the pattern is restricted to be used with.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -131,11 +131,11 @@
 			<tr id="schema-template_types">
 			<td>
 				<code>template_types</code>
-				</td>
-				<td>
-					<p>An array of template types where the pattern fits.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>An array of template types where the pattern fits.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -143,11 +143,11 @@
 			<tr id="schema-source">
 			<td>
 				<code>source</code>
-				</td>
-				<td>
-					<p>Where the pattern comes from e.g. core</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Where the pattern comes from e.g. core</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>core</code>, <code>plugin</code>, <code>theme</code>, <code>pattern-directory/core</code>, <code>pattern-directory/theme</code>, <code>pattern-directory/featured</code></p>

--- a/reference/block-patterns.md
+++ b/reference/block-patterns.md
@@ -10,134 +10,147 @@
 <table class="attributes">
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The pattern name.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The pattern name.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The pattern title, in human readable format.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The pattern title, in human readable format.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The pattern content.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The pattern content.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The pattern detailed description.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>The pattern detailed description.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-viewport_width">
 			<td>
-				<code>viewport_width</code><br />
-				<span class="type">
-					number				</span>
-			</td>
-			<td>
-				<p>The pattern viewport width for inserter preview.</p>
+				<code>viewport_width</code>
+				</td>
+				<td>
+					<p>The pattern viewport width for inserter preview.</p>
+					<p class="type">
+						JSON data type: number				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-inserter">
 			<td>
-				<code>inserter</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Determines whether the pattern is visible in inserter.</p>
+				<code>inserter</code>
+				</td>
+				<td>
+					<p>Determines whether the pattern is visible in inserter.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-categories">
 			<td>
-				<code>categories</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>The pattern category slugs.</p>
+				<code>categories</code>
+				</td>
+				<td>
+					<p>The pattern category slugs.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-keywords">
 			<td>
-				<code>keywords</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>The pattern keywords.</p>
+				<code>keywords</code>
+				</td>
+				<td>
+					<p>The pattern keywords.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-block_types">
 			<td>
-				<code>block_types</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Block types that the pattern is intended to be used with.</p>
+				<code>block_types</code>
+				</td>
+				<td>
+					<p>Block types that the pattern is intended to be used with.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-post_types">
 			<td>
-				<code>post_types</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>An array of post types that the pattern is restricted to be used with.</p>
+				<code>post_types</code>
+				</td>
+				<td>
+					<p>An array of post types that the pattern is restricted to be used with.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template_types">
 			<td>
-				<code>template_types</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>An array of template types where the pattern fits.</p>
+				<code>template_types</code>
+				</td>
+				<td>
+					<p>An array of template types where the pattern fits.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
+							</td>
+		</tr>
+			<tr id="schema-source">
+			<td>
+				<code>source</code>
+				</td>
+				<td>
+					<p>Where the pattern comes from e.g. core</p>
+					<p class="type">
+						JSON data type: string				</p>
+									<p class="read-only">Read only</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
+									<p>One of: <code>core</code>, <code>plugin</code>, <code>theme</code>, <code>pattern-directory/core</code>, <code>pattern-directory/theme</code>, <code>pattern-directory/featured</code></p>
 							</td>
 		</tr>
 	</table>

--- a/reference/block-revisions.md
+++ b/reference/block-revisions.md
@@ -10,131 +10,131 @@
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the revision.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the revision was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The globally unique identifier for the post.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>The globally unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the revision.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the revision.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the revision unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The title for the post.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The content for the post.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The content for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
@@ -454,6 +454,14 @@
 									</td>
 				<td>
 											<p>The content for the post.</p>
+																								</td>
+			</tr>
+					<tr>
+				<td>
+											<code><a href="#schema-meta">meta</a></code><br />
+									</td>
+				<td>
+											<p>Meta fields.</p>
 																								</td>
 			</tr>
 					<tr>

--- a/reference/block-revisions.md
+++ b/reference/block-revisions.md
@@ -11,48 +11,48 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the revision was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>The globally unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The globally unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -60,81 +60,81 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the revision unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The title for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The content for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The content for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/block-types.md
+++ b/reference/block-types.md
@@ -11,11 +11,11 @@
 			<tr id="schema-api_version">
 			<td>
 				<code>api_version</code>
-				</td>
-				<td>
-					<p>Version of block API.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Version of block API.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>Title of block type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Title of block type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>Unique name identifying the block type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Unique name identifying the block type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -47,11 +47,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>Description of block type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Description of block type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -59,11 +59,11 @@
 			<tr id="schema-icon">
 			<td>
 				<code>icon</code>
-				</td>
-				<td>
-					<p>Icon of block type.</p>
-					<p class="type">
-						JSON data type: string or null				</p>
+			</td>
+			<td>
+				<p>Icon of block type.</p>
+				<p class="type">
+					JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -71,11 +71,11 @@
 			<tr id="schema-attributes">
 			<td>
 				<code>attributes</code>
-				</td>
-				<td>
-					<p>Block attributes.</p>
-					<p class="type">
-						JSON data type: object or null				</p>
+			</td>
+			<td>
+				<p>Block attributes.</p>
+				<p class="type">
+					JSON data type: object or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -83,11 +83,11 @@
 			<tr id="schema-provides_context">
 			<td>
 				<code>provides_context</code>
-				</td>
-				<td>
-					<p>Context provided by blocks of this type.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Context provided by blocks of this type.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -95,11 +95,11 @@
 			<tr id="schema-uses_context">
 			<td>
 				<code>uses_context</code>
-				</td>
-				<td>
-					<p>Context values inherited by blocks of this type.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Context values inherited by blocks of this type.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -107,11 +107,11 @@
 			<tr id="schema-selectors">
 			<td>
 				<code>selectors</code>
-				</td>
-				<td>
-					<p>Custom CSS selectors.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Custom CSS selectors.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -119,11 +119,11 @@
 			<tr id="schema-supports">
 			<td>
 				<code>supports</code>
-				</td>
-				<td>
-					<p>Block supports.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Block supports.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -131,11 +131,11 @@
 			<tr id="schema-category">
 			<td>
 				<code>category</code>
-				</td>
-				<td>
-					<p>Block category.</p>
-					<p class="type">
-						JSON data type: string or null				</p>
+			</td>
+			<td>
+				<p>Block category.</p>
+				<p class="type">
+					JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -143,11 +143,11 @@
 			<tr id="schema-is_dynamic">
 			<td>
 				<code>is_dynamic</code>
-				</td>
-				<td>
-					<p>Is the block dynamically rendered.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Is the block dynamically rendered.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -155,11 +155,11 @@
 			<tr id="schema-editor_script_handles">
 			<td>
 				<code>editor_script_handles</code>
-				</td>
-				<td>
-					<p>Editor script handles.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Editor script handles.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -167,11 +167,11 @@
 			<tr id="schema-script_handles">
 			<td>
 				<code>script_handles</code>
-				</td>
-				<td>
-					<p>Public facing and editor script handles.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Public facing and editor script handles.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -179,11 +179,11 @@
 			<tr id="schema-view_script_handles">
 			<td>
 				<code>view_script_handles</code>
-				</td>
-				<td>
-					<p>Public facing script handles.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Public facing script handles.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -191,11 +191,11 @@
 			<tr id="schema-editor_style_handles">
 			<td>
 				<code>editor_style_handles</code>
-				</td>
-				<td>
-					<p>Editor style handles.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Editor style handles.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -203,11 +203,11 @@
 			<tr id="schema-style_handles">
 			<td>
 				<code>style_handles</code>
-				</td>
-				<td>
-					<p>Public facing and editor style handles.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Public facing and editor style handles.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -215,11 +215,11 @@
 			<tr id="schema-styles">
 			<td>
 				<code>styles</code>
-				</td>
-				<td>
-					<p>Block style variations.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Block style variations.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -227,11 +227,11 @@
 			<tr id="schema-variations">
 			<td>
 				<code>variations</code>
-				</td>
-				<td>
-					<p>Block variations.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Block variations.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -239,11 +239,11 @@
 			<tr id="schema-textdomain">
 			<td>
 				<code>textdomain</code>
-				</td>
-				<td>
-					<p>Public text domain.</p>
-					<p class="type">
-						JSON data type: string or null				</p>
+			</td>
+			<td>
+				<p>Public text domain.</p>
+				<p class="type">
+					JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -251,11 +251,11 @@
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>Parent blocks.</p>
-					<p class="type">
-						JSON data type: array or null				</p>
+			</td>
+			<td>
+				<p>Parent blocks.</p>
+				<p class="type">
+					JSON data type: array or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -263,11 +263,11 @@
 			<tr id="schema-ancestor">
 			<td>
 				<code>ancestor</code>
-				</td>
-				<td>
-					<p>Ancestor blocks.</p>
-					<p class="type">
-						JSON data type: array or null				</p>
+			</td>
+			<td>
+				<p>Ancestor blocks.</p>
+				<p class="type">
+					JSON data type: array or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -275,11 +275,11 @@
 			<tr id="schema-keywords">
 			<td>
 				<code>keywords</code>
-				</td>
-				<td>
-					<p>Block keywords.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Block keywords.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -287,11 +287,11 @@
 			<tr id="schema-example">
 			<td>
 				<code>example</code>
-				</td>
-				<td>
-					<p>Block example.</p>
-					<p class="type">
-						JSON data type: object or null				</p>
+			</td>
+			<td>
+				<p>Block example.</p>
+				<p class="type">
+					JSON data type: object or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -299,11 +299,11 @@
 			<tr id="schema-editor_script">
 			<td>
 				<code>editor_script</code>
-				</td>
-				<td>
-					<p>Editor script handle. DEPRECATED: Use `editor_script_handles` instead.</p>
-					<p class="type">
-						JSON data type: string or null				</p>
+			</td>
+			<td>
+				<p>Editor script handle. DEPRECATED: Use `editor_script_handles` instead.</p>
+				<p class="type">
+					JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -311,11 +311,11 @@
 			<tr id="schema-script">
 			<td>
 				<code>script</code>
-				</td>
-				<td>
-					<p>Public facing and editor script handle. DEPRECATED: Use `script_handles` instead.</p>
-					<p class="type">
-						JSON data type: string or null				</p>
+			</td>
+			<td>
+				<p>Public facing and editor script handle. DEPRECATED: Use `script_handles` instead.</p>
+				<p class="type">
+					JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -323,11 +323,11 @@
 			<tr id="schema-view_script">
 			<td>
 				<code>view_script</code>
-				</td>
-				<td>
-					<p>Public facing script handle. DEPRECATED: Use `view_script_handles` instead.</p>
-					<p class="type">
-						JSON data type: string or null				</p>
+			</td>
+			<td>
+				<p>Public facing script handle. DEPRECATED: Use `view_script_handles` instead.</p>
+				<p class="type">
+					JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -335,11 +335,11 @@
 			<tr id="schema-editor_style">
 			<td>
 				<code>editor_style</code>
-				</td>
-				<td>
-					<p>Editor style handle. DEPRECATED: Use `editor_style_handles` instead.</p>
-					<p class="type">
-						JSON data type: string or null				</p>
+			</td>
+			<td>
+				<p>Editor style handle. DEPRECATED: Use `editor_style_handles` instead.</p>
+				<p class="type">
+					JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -347,11 +347,11 @@
 			<tr id="schema-style">
 			<td>
 				<code>style</code>
-				</td>
-				<td>
-					<p>Public facing and editor style handle. DEPRECATED: Use `style_handles` instead.</p>
-					<p class="type">
-						JSON data type: string or null				</p>
+			</td>
+			<td>
+				<p>Public facing and editor style handle. DEPRECATED: Use `style_handles` instead.</p>
+				<p class="type">
+					JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/block-types.md
+++ b/reference/block-types.md
@@ -10,336 +10,348 @@
 <table class="attributes">
 			<tr id="schema-api_version">
 			<td>
-				<code>api_version</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Version of block API.</p>
+				<code>api_version</code>
+				</td>
+				<td>
+					<p>Version of block API.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Title of block type.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>Title of block type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Unique name identifying the block type.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>Unique name identifying the block type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Description of block type.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>Description of block type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-icon">
 			<td>
-				<code>icon</code><br />
-				<span class="type">
-					string or null				</span>
-			</td>
-			<td>
-				<p>Icon of block type.</p>
+				<code>icon</code>
+				</td>
+				<td>
+					<p>Icon of block type.</p>
+					<p class="type">
+						JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-attributes">
 			<td>
-				<code>attributes</code><br />
-				<span class="type">
-					object or null				</span>
-			</td>
-			<td>
-				<p>Block attributes.</p>
+				<code>attributes</code>
+				</td>
+				<td>
+					<p>Block attributes.</p>
+					<p class="type">
+						JSON data type: object or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-provides_context">
 			<td>
-				<code>provides_context</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Context provided by blocks of this type.</p>
+				<code>provides_context</code>
+				</td>
+				<td>
+					<p>Context provided by blocks of this type.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-uses_context">
 			<td>
-				<code>uses_context</code><br />
-				<span class="type">
-					array				</span>
-			</td>
+				<code>uses_context</code>
+				</td>
+				<td>
+					<p>Context values inherited by blocks of this type.</p>
+					<p class="type">
+						JSON data type: array				</p>
+									<p class="read-only">Read only</p>
+								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
+							</td>
+		</tr>
+			<tr id="schema-selectors">
 			<td>
-				<p>Context values inherited by blocks of this type.</p>
+				<code>selectors</code>
+				</td>
+				<td>
+					<p>Custom CSS selectors.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-supports">
 			<td>
-				<code>supports</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Block supports.</p>
+				<code>supports</code>
+				</td>
+				<td>
+					<p>Block supports.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-category">
 			<td>
-				<code>category</code><br />
-				<span class="type">
-					string or null				</span>
-			</td>
-			<td>
-				<p>Block category.</p>
+				<code>category</code>
+				</td>
+				<td>
+					<p>Block category.</p>
+					<p class="type">
+						JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-is_dynamic">
 			<td>
-				<code>is_dynamic</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Is the block dynamically rendered.</p>
+				<code>is_dynamic</code>
+				</td>
+				<td>
+					<p>Is the block dynamically rendered.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-editor_script_handles">
 			<td>
-				<code>editor_script_handles</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Editor script handles.</p>
+				<code>editor_script_handles</code>
+				</td>
+				<td>
+					<p>Editor script handles.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-script_handles">
 			<td>
-				<code>script_handles</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Public facing and editor script handles.</p>
+				<code>script_handles</code>
+				</td>
+				<td>
+					<p>Public facing and editor script handles.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-view_script_handles">
 			<td>
-				<code>view_script_handles</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Public facing script handles.</p>
+				<code>view_script_handles</code>
+				</td>
+				<td>
+					<p>Public facing script handles.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-editor_style_handles">
 			<td>
-				<code>editor_style_handles</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Editor style handles.</p>
+				<code>editor_style_handles</code>
+				</td>
+				<td>
+					<p>Editor style handles.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-style_handles">
 			<td>
-				<code>style_handles</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Public facing and editor style handles.</p>
+				<code>style_handles</code>
+				</td>
+				<td>
+					<p>Public facing and editor style handles.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-styles">
 			<td>
-				<code>styles</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Block style variations.</p>
+				<code>styles</code>
+				</td>
+				<td>
+					<p>Block style variations.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-variations">
 			<td>
-				<code>variations</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Block variations.</p>
+				<code>variations</code>
+				</td>
+				<td>
+					<p>Block variations.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-textdomain">
 			<td>
-				<code>textdomain</code><br />
-				<span class="type">
-					string or null				</span>
-			</td>
-			<td>
-				<p>Public text domain.</p>
+				<code>textdomain</code>
+				</td>
+				<td>
+					<p>Public text domain.</p>
+					<p class="type">
+						JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					array or null				</span>
-			</td>
-			<td>
-				<p>Parent blocks.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>Parent blocks.</p>
+					<p class="type">
+						JSON data type: array or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-ancestor">
 			<td>
-				<code>ancestor</code><br />
-				<span class="type">
-					array or null				</span>
-			</td>
-			<td>
-				<p>Ancestor blocks.</p>
+				<code>ancestor</code>
+				</td>
+				<td>
+					<p>Ancestor blocks.</p>
+					<p class="type">
+						JSON data type: array or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-keywords">
 			<td>
-				<code>keywords</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Block keywords.</p>
+				<code>keywords</code>
+				</td>
+				<td>
+					<p>Block keywords.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-example">
 			<td>
-				<code>example</code><br />
-				<span class="type">
-					object or null				</span>
-			</td>
-			<td>
-				<p>Block example.</p>
+				<code>example</code>
+				</td>
+				<td>
+					<p>Block example.</p>
+					<p class="type">
+						JSON data type: object or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-editor_script">
 			<td>
-				<code>editor_script</code><br />
-				<span class="type">
-					string or null				</span>
-			</td>
-			<td>
-				<p>Editor script handle. DEPRECATED: Use `editor_script_handles` instead.</p>
+				<code>editor_script</code>
+				</td>
+				<td>
+					<p>Editor script handle. DEPRECATED: Use `editor_script_handles` instead.</p>
+					<p class="type">
+						JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-script">
 			<td>
-				<code>script</code><br />
-				<span class="type">
-					string or null				</span>
-			</td>
-			<td>
-				<p>Public facing and editor script handle. DEPRECATED: Use `script_handles` instead.</p>
+				<code>script</code>
+				</td>
+				<td>
+					<p>Public facing and editor script handle. DEPRECATED: Use `script_handles` instead.</p>
+					<p class="type">
+						JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-view_script">
 			<td>
-				<code>view_script</code><br />
-				<span class="type">
-					string or null				</span>
-			</td>
-			<td>
-				<p>Public facing script handle. DEPRECATED: Use `view_script_handles` instead.</p>
+				<code>view_script</code>
+				</td>
+				<td>
+					<p>Public facing script handle. DEPRECATED: Use `view_script_handles` instead.</p>
+					<p class="type">
+						JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-editor_style">
 			<td>
-				<code>editor_style</code><br />
-				<span class="type">
-					string or null				</span>
-			</td>
-			<td>
-				<p>Editor style handle. DEPRECATED: Use `editor_style_handles` instead.</p>
+				<code>editor_style</code>
+				</td>
+				<td>
+					<p>Editor style handle. DEPRECATED: Use `editor_style_handles` instead.</p>
+					<p class="type">
+						JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-style">
 			<td>
-				<code>style</code><br />
-				<span class="type">
-					string or null				</span>
-			</td>
-			<td>
-				<p>Public facing and editor style handle. DEPRECATED: Use `style_handles` instead.</p>
+				<code>style</code>
+				</td>
+				<td>
+					<p>Public facing and editor style handle. DEPRECATED: Use `style_handles` instead.</p>
+					<p class="type">
+						JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/blocks.md
+++ b/reference/blocks.md
@@ -11,37 +11,37 @@
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the post was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>The globally unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The globally unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -49,11 +49,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -61,13 +61,13 @@
 			<tr id="schema-link">
 			<td>
 				<code>link</code>
-				</td>
-				<td>
-					<p>URL to the post.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL to the post.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -75,13 +75,13 @@
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -89,13 +89,13 @@
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -103,22 +103,22 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the post unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>A named status for the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A named status for the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
@@ -126,11 +126,11 @@
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>Type of post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type of post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -138,55 +138,55 @@
 			<tr id="schema-password">
 			<td>
 				<code>password</code>
-				</td>
-				<td>
-					<p>A password to protect access to the content and excerpt.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A password to protect access to the content and excerpt.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The title for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The content for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The content for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
 				<code>template</code>
-				</td>
-				<td>
-					<p>The theme file to use to display the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The theme file to use to display the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/blocks.md
+++ b/reference/blocks.md
@@ -10,172 +10,183 @@
 <table class="attributes">
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the post was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The globally unique identifier for the post.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>The globally unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the post.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
-				<code>link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL to the post.</p>
+				<code>link</code>
+				</td>
+				<td>
+					<p>URL to the post.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the post unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A named status for the post.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>A named status for the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type of post.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>Type of post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-password">
 			<td>
-				<code>password</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A password to protect access to the content and excerpt.</p>
+				<code>password</code>
+				</td>
+				<td>
+					<p>A password to protect access to the content and excerpt.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The title for the post.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object				</span>
-			</td>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The content for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+							</td>
+		</tr>
+			<tr id="schema-meta">
 			<td>
-				<p>The content for the post.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
-				<code>template</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The theme file to use to display the post.</p>
+				<code>template</code>
+				</td>
+				<td>
+					<p>The theme file to use to display the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
@@ -417,6 +428,14 @@
 			</tr>
 					<tr>
 				<td>
+											<code><a href="#schema-meta">meta</a></code><br />
+									</td>
+				<td>
+											<p>Meta fields.</p>
+																								</td>
+			</tr>
+					<tr>
+				<td>
 											<code><a href="#schema-template">template</a></code><br />
 									</td>
 				<td>
@@ -547,6 +566,14 @@
 									</td>
 				<td>
 											<p>The content for the post.</p>
+																								</td>
+			</tr>
+					<tr>
+				<td>
+											<code><a href="#schema-meta">meta</a></code><br />
+									</td>
+				<td>
+											<p>Meta fields.</p>
 																								</td>
 			</tr>
 					<tr>

--- a/reference/categories.md
+++ b/reference/categories.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the term.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the term.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-count">
 			<td>
 				<code>count</code>
-				</td>
-				<td>
-					<p>Number of published posts for the term.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Number of published posts for the term.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -35,24 +35,24 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>HTML description of the term.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML description of the term.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
 				<code>link</code>
-				</td>
-				<td>
-					<p>URL of the term.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL of the term.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
@@ -60,33 +60,33 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>HTML title for the term.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML title for the term.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the term unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the term unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-taxonomy">
 			<td>
 				<code>taxonomy</code>
-				</td>
-				<td>
-					<p>Type attribution for the term.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type attribution for the term.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 									<p>One of: <code>category</code></p>
@@ -95,22 +95,22 @@
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The parent term ID.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The parent term ID.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/categories.md
+++ b/reference/categories.md
@@ -10,83 +10,83 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the term.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the term.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-count">
 			<td>
-				<code>count</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Number of published posts for the term.</p>
+				<code>count</code>
+				</td>
+				<td>
+					<p>Number of published posts for the term.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML description of the term.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>HTML description of the term.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
-				<code>link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL of the term.</p>
+				<code>link</code>
+				</td>
+				<td>
+					<p>URL of the term.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML title for the term.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>HTML title for the term.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the term unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the term unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-taxonomy">
 			<td>
-				<code>taxonomy</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type attribution for the term.</p>
+				<code>taxonomy</code>
+				</td>
+				<td>
+					<p>Type attribution for the term.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 									<p>One of: <code>category</code></p>
@@ -94,23 +94,23 @@
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The parent term ID.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The parent term ID.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
-				<code>meta</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Meta fields.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/comments.md
+++ b/reference/comments.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the comment.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the comment.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -23,23 +23,23 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID of the user object, if author was a user.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID of the user object, if author was a user.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_email">
 			<td>
 				<code>author_email</code>
-				</td>
-				<td>
-					<p>Email address for the comment author.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: email
+			</td>
+			<td>
+				<p>Email address for the comment author.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: email
 									</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -47,12 +47,12 @@
 			<tr id="schema-author_ip">
 			<td>
 				<code>author_ip</code>
-				</td>
-				<td>
-					<p>IP address for the comment author.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: ip
+			</td>
+			<td>
+				<p>IP address for the comment author.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: ip
 									</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -60,85 +60,85 @@
 			<tr id="schema-author_name">
 			<td>
 				<code>author_name</code>
-				</td>
-				<td>
-					<p>Display name for the comment author.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Display name for the comment author.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_url">
 			<td>
 				<code>author_url</code>
-				</td>
-				<td>
-					<p>URL for the comment author.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL for the comment author.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_user_agent">
 			<td>
 				<code>author_user_agent</code>
-				</td>
-				<td>
-					<p>User agent for the comment author.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>User agent for the comment author.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The content for the comment.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The content for the comment.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the comment was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the comment was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the comment was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the comment was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
 				<code>link</code>
-				</td>
-				<td>
-					<p>URL to the comment.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL to the comment.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -146,44 +146,44 @@
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the comment.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the comment.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-post">
 			<td>
 				<code>post</code>
-				</td>
-				<td>
-					<p>The ID of the associated post object.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID of the associated post object.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>State of the comment.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>State of the comment.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>Type of the comment.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type of the comment.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -191,11 +191,11 @@
 			<tr id="schema-author_avatar_urls">
 			<td>
 				<code>author_avatar_urls</code>
-				</td>
-				<td>
-					<p>Avatar URLs for the comment author.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Avatar URLs for the comment author.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -203,11 +203,11 @@
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/comments.md
+++ b/reference/comments.md
@@ -10,204 +10,204 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the comment.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the comment.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID of the user object, if author was a user.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID of the user object, if author was a user.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_email">
 			<td>
-				<code>author_email</code><br />
-				<span class="type">
-					string,
-													email
-									</span>
-			</td>
-			<td>
-				<p>Email address for the comment author.</p>
+				<code>author_email</code>
+				</td>
+				<td>
+					<p>Email address for the comment author.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: email
+									</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_ip">
 			<td>
-				<code>author_ip</code><br />
-				<span class="type">
-					string,
-													ip
-									</span>
-			</td>
-			<td>
-				<p>IP address for the comment author.</p>
+				<code>author_ip</code>
+				</td>
+				<td>
+					<p>IP address for the comment author.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: ip
+									</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_name">
 			<td>
-				<code>author_name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Display name for the comment author.</p>
+				<code>author_name</code>
+				</td>
+				<td>
+					<p>Display name for the comment author.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_url">
 			<td>
-				<code>author_url</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL for the comment author.</p>
+				<code>author_url</code>
+				</td>
+				<td>
+					<p>URL for the comment author.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_user_agent">
 			<td>
-				<code>author_user_agent</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>User agent for the comment author.</p>
+				<code>author_user_agent</code>
+				</td>
+				<td>
+					<p>User agent for the comment author.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The content for the comment.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The content for the comment.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the comment was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the comment was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the comment was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the comment was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
-				<code>link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL to the comment.</p>
+				<code>link</code>
+				</td>
+				<td>
+					<p>URL to the comment.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the comment.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the comment.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-post">
 			<td>
-				<code>post</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID of the associated post object.</p>
+				<code>post</code>
+				</td>
+				<td>
+					<p>The ID of the associated post object.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>State of the comment.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>State of the comment.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type of the comment.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>Type of the comment.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_avatar_urls">
 			<td>
-				<code>author_avatar_urls</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Avatar URLs for the comment author.</p>
+				<code>author_avatar_urls</code>
+				</td>
+				<td>
+					<p>Avatar URLs for the comment author.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
-				<code>meta</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Meta fields.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/media.md
+++ b/reference/media.md
@@ -11,37 +11,37 @@
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the post was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>The globally unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The globally unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -49,11 +49,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -61,13 +61,13 @@
 			<tr id="schema-link">
 			<td>
 				<code>link</code>
-				</td>
-				<td>
-					<p>URL to the post.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL to the post.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -75,13 +75,13 @@
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -89,13 +89,13 @@
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -103,22 +103,22 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the post unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>A named status for the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A named status for the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
@@ -126,11 +126,11 @@
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>Type of post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type of post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -138,11 +138,11 @@
 			<tr id="schema-permalink_template">
 			<td>
 				<code>permalink_template</code>
-				</td>
-				<td>
-					<p>Permalink template for the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Permalink template for the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -150,11 +150,11 @@
 			<tr id="schema-generated_slug">
 			<td>
 				<code>generated_slug</code>
-				</td>
-				<td>
-					<p>Slug automatically generated from the post title.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Slug automatically generated from the post title.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -162,33 +162,33 @@
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The title for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-comment_status">
 			<td>
 				<code>comment_status</code>
-				</td>
-				<td>
-					<p>Whether or not comments are open on the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Whether or not comments are open on the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
@@ -196,11 +196,11 @@
 			<tr id="schema-ping_status">
 			<td>
 				<code>ping_status</code>
-				</td>
-				<td>
-					<p>Whether or not the post can be pinged.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Whether or not the post can be pinged.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
@@ -208,66 +208,66 @@
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
 				<code>template</code>
-				</td>
-				<td>
-					<p>The theme file to use to display the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The theme file to use to display the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-alt_text">
 			<td>
 				<code>alt_text</code>
-				</td>
-				<td>
-					<p>Alternative text to display when attachment is not displayed.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Alternative text to display when attachment is not displayed.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-caption">
 			<td>
 				<code>caption</code>
-				</td>
-				<td>
-					<p>The attachment caption.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The attachment caption.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>The attachment description.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The attachment description.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-media_type">
 			<td>
 				<code>media_type</code>
-				</td>
-				<td>
-					<p>Attachment type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Attachment type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>image</code>, <code>file</code></p>
@@ -276,11 +276,11 @@
 			<tr id="schema-mime_type">
 			<td>
 				<code>mime_type</code>
-				</td>
-				<td>
-					<p>The attachment MIME type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The attachment MIME type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -288,11 +288,11 @@
 			<tr id="schema-media_details">
 			<td>
 				<code>media_details</code>
-				</td>
-				<td>
-					<p>Details about the media file, specific to its type.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Details about the media file, specific to its type.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -300,24 +300,24 @@
 			<tr id="schema-post">
 			<td>
 				<code>post</code>
-				</td>
-				<td>
-					<p>The ID for the associated post of the attachment.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the associated post of the attachment.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-source_url">
 			<td>
 				<code>source_url</code>
-				</td>
-				<td>
-					<p>URL to the original attachment file.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL to the original attachment file.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -325,11 +325,11 @@
 			<tr id="schema-missing_image_sizes">
 			<td>
 				<code>missing_image_sizes</code>
-				</td>
-				<td>
-					<p>List of the missing image sizes of the attachment.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>List of the missing image sizes of the attachment.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>

--- a/reference/media.md
+++ b/reference/media.md
@@ -10,264 +10,264 @@
 <table class="attributes">
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the post was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The globally unique identifier for the post.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>The globally unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the post.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
-				<code>link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL to the post.</p>
+				<code>link</code>
+				</td>
+				<td>
+					<p>URL to the post.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the post unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A named status for the post.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>A named status for the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type of post.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>Type of post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-permalink_template">
 			<td>
-				<code>permalink_template</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Permalink template for the post.</p>
+				<code>permalink_template</code>
+				</td>
+				<td>
+					<p>Permalink template for the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-generated_slug">
 			<td>
-				<code>generated_slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Slug automatically generated from the post title.</p>
+				<code>generated_slug</code>
+				</td>
+				<td>
+					<p>Slug automatically generated from the post title.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The title for the post.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the post.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-comment_status">
 			<td>
-				<code>comment_status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Whether or not comments are open on the post.</p>
+				<code>comment_status</code>
+				</td>
+				<td>
+					<p>Whether or not comments are open on the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-ping_status">
 			<td>
-				<code>ping_status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Whether or not the post can be pinged.</p>
+				<code>ping_status</code>
+				</td>
+				<td>
+					<p>Whether or not the post can be pinged.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
-				<code>meta</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Meta fields.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
-				<code>template</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The theme file to use to display the post.</p>
+				<code>template</code>
+				</td>
+				<td>
+					<p>The theme file to use to display the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-alt_text">
 			<td>
-				<code>alt_text</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Alternative text to display when attachment is not displayed.</p>
+				<code>alt_text</code>
+				</td>
+				<td>
+					<p>Alternative text to display when attachment is not displayed.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-caption">
 			<td>
-				<code>caption</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The attachment caption.</p>
+				<code>caption</code>
+				</td>
+				<td>
+					<p>The attachment caption.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The attachment description.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>The attachment description.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-media_type">
 			<td>
-				<code>media_type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Attachment type.</p>
+				<code>media_type</code>
+				</td>
+				<td>
+					<p>Attachment type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>image</code>, <code>file</code></p>
@@ -275,61 +275,61 @@
 		</tr>
 			<tr id="schema-mime_type">
 			<td>
-				<code>mime_type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The attachment MIME type.</p>
+				<code>mime_type</code>
+				</td>
+				<td>
+					<p>The attachment MIME type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-media_details">
 			<td>
-				<code>media_details</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Details about the media file, specific to its type.</p>
+				<code>media_details</code>
+				</td>
+				<td>
+					<p>Details about the media file, specific to its type.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-post">
 			<td>
-				<code>post</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the associated post of the attachment.</p>
+				<code>post</code>
+				</td>
+				<td>
+					<p>The ID for the associated post of the attachment.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-source_url">
 			<td>
-				<code>source_url</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL to the original attachment file.</p>
+				<code>source_url</code>
+				</td>
+				<td>
+					<p>URL to the original attachment file.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-missing_image_sizes">
 			<td>
-				<code>missing_image_sizes</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>List of the missing image sizes of the attachment.</p>
+				<code>missing_image_sizes</code>
+				</td>
+				<td>
+					<p>List of the missing image sizes of the attachment.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>

--- a/reference/menu-locations.md
+++ b/reference/menu-locations.md
@@ -11,11 +11,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The name of the menu location.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The name of the menu location.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>The description of the menu location.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The description of the menu location.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-menu">
 			<td>
 				<code>menu</code>
-				</td>
-				<td>
-					<p>The ID of the assigned menu.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID of the assigned menu.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/menu-locations.md
+++ b/reference/menu-locations.md
@@ -10,36 +10,36 @@
 <table class="attributes">
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The name of the menu location.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The name of the menu location.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The description of the menu location.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>The description of the menu location.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-menu">
 			<td>
-				<code>menu</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID of the assigned menu.</p>
+				<code>menu</code>
+				</td>
+				<td>
+					<p>The ID of the assigned menu.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/nav_menu_item-revisions.md
+++ b/reference/nav_menu_item-revisions.md
@@ -10,132 +10,132 @@
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the revision.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the revision was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>GUID for the revision, as it exists in the database.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>GUID for the revision, as it exists in the database.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the revision.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the revision.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the revision unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					string or object				</span>
-			</td>
-			<td>
-				<p>The title for the object.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the object.</p>
+					<p class="type">
+						JSON data type: string or object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-preview_link">
 			<td>
-				<code>preview_link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>Preview link for the post.</p>
+				<code>preview_link</code>
+				</td>
+				<td>
+					<p>Preview link for the post.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>

--- a/reference/nav_menu_item-revisions.md
+++ b/reference/nav_menu_item-revisions.md
@@ -11,131 +11,131 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the revision was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>GUID for the revision, as it exists in the database.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>GUID for the revision, as it exists in the database.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the revision unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the object.</p>
-					<p class="type">
-						JSON data type: string or object				</p>
+			</td>
+			<td>
+				<p>The title for the object.</p>
+				<p class="type">
+					JSON data type: string or object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-preview_link">
 			<td>
 				<code>preview_link</code>
-				</td>
-				<td>
-					<p>Preview link for the post.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>Preview link for the post.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>

--- a/reference/nav_menu_items.md
+++ b/reference/nav_menu_items.md
@@ -10,207 +10,207 @@
 <table class="attributes">
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					string or object				</span>
-			</td>
-			<td>
-				<p>The title for the object.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the object.</p>
+					<p class="type">
+						JSON data type: string or object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the object.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the object.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type_label">
 			<td>
-				<code>type_label</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The singular label used to describe this type of menu item.</p>
+				<code>type_label</code>
+				</td>
+				<td>
+					<p>The singular label used to describe this type of menu item.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The family of objects originally represented, such as &quot;post_type&quot; or &quot;taxonomy&quot;.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>The family of objects originally represented, such as &quot;post_type&quot; or &quot;taxonomy&quot;.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>taxonomy</code>, <code>post_type</code>, <code>post_type_archive</code>, <code>custom</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A named status for the object.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>A named status for the object.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the object.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the object.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-attr_title">
 			<td>
-				<code>attr_title</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Text for the title attribute of the link element for this menu item.</p>
+				<code>attr_title</code>
+				</td>
+				<td>
+					<p>Text for the title attribute of the link element for this menu item.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-classes">
 			<td>
-				<code>classes</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Class names for the link element of this menu item.</p>
+				<code>classes</code>
+				</td>
+				<td>
+					<p>Class names for the link element of this menu item.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The description of this menu item.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>The description of this menu item.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-menu_order">
 			<td>
-				<code>menu_order</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The DB ID of the nav_menu_item that is this item&#039;s menu parent, if any, otherwise 0.</p>
+				<code>menu_order</code>
+				</td>
+				<td>
+					<p>The DB ID of the nav_menu_item that is this item&#039;s menu parent, if any, otherwise 0.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-object">
 			<td>
-				<code>object</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The type of object originally represented, such as &quot;category&quot;, &quot;post&quot;, or &quot;attachment&quot;.</p>
+				<code>object</code>
+				</td>
+				<td>
+					<p>The type of object originally represented, such as &quot;category&quot;, &quot;post&quot;, or &quot;attachment&quot;.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-object_id">
 			<td>
-				<code>object_id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The database ID of the original object this menu item represents, for example the ID for posts or the term_id for categories.</p>
+				<code>object_id</code>
+				</td>
+				<td>
+					<p>The database ID of the original object this menu item represents, for example the ID for posts or the term_id for categories.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-target">
 			<td>
-				<code>target</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The target attribute of the link element for this menu item.</p>
+				<code>target</code>
+				</td>
+				<td>
+					<p>The target attribute of the link element for this menu item.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>_blank</code>, <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-url">
 			<td>
-				<code>url</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>The URL to which this menu item points.</p>
+				<code>url</code>
+				</td>
+				<td>
+					<p>The URL to which this menu item points.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-xfn">
 			<td>
-				<code>xfn</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>The XFN relationship expressed in the link of this menu item.</p>
+				<code>xfn</code>
+				</td>
+				<td>
+					<p>The XFN relationship expressed in the link of this menu item.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-invalid">
 			<td>
-				<code>invalid</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether the menu item represents an object that no longer exists.</p>
+				<code>invalid</code>
+				</td>
+				<td>
+					<p>Whether the menu item represents an object that no longer exists.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-menus">
 			<td>
-				<code>menus</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The terms assigned to the object in the nav_menu taxonomy.</p>
+				<code>menus</code>
+				</td>
+				<td>
+					<p>The terms assigned to the object in the nav_menu taxonomy.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
-				<code>meta</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Meta fields.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/nav_menu_items.md
+++ b/reference/nav_menu_items.md
@@ -11,22 +11,22 @@
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the object.</p>
-					<p class="type">
-						JSON data type: string or object				</p>
+			</td>
+			<td>
+				<p>The title for the object.</p>
+				<p class="type">
+					JSON data type: string or object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the object.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the object.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -34,11 +34,11 @@
 			<tr id="schema-type_label">
 			<td>
 				<code>type_label</code>
-				</td>
-				<td>
-					<p>The singular label used to describe this type of menu item.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The singular label used to describe this type of menu item.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -46,11 +46,11 @@
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>The family of objects originally represented, such as &quot;post_type&quot; or &quot;taxonomy&quot;.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The family of objects originally represented, such as &quot;post_type&quot; or &quot;taxonomy&quot;.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>taxonomy</code>, <code>post_type</code>, <code>post_type_archive</code>, <code>custom</code></p>
 							</td>
@@ -58,11 +58,11 @@
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>A named status for the object.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A named status for the object.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
@@ -70,88 +70,88 @@
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the object.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the object.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-attr_title">
 			<td>
 				<code>attr_title</code>
-				</td>
-				<td>
-					<p>Text for the title attribute of the link element for this menu item.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Text for the title attribute of the link element for this menu item.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-classes">
 			<td>
 				<code>classes</code>
-				</td>
-				<td>
-					<p>Class names for the link element of this menu item.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Class names for the link element of this menu item.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>The description of this menu item.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The description of this menu item.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-menu_order">
 			<td>
 				<code>menu_order</code>
-				</td>
-				<td>
-					<p>The DB ID of the nav_menu_item that is this item&#039;s menu parent, if any, otherwise 0.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The DB ID of the nav_menu_item that is this item&#039;s menu parent, if any, otherwise 0.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-object">
 			<td>
 				<code>object</code>
-				</td>
-				<td>
-					<p>The type of object originally represented, such as &quot;category&quot;, &quot;post&quot;, or &quot;attachment&quot;.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The type of object originally represented, such as &quot;category&quot;, &quot;post&quot;, or &quot;attachment&quot;.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-object_id">
 			<td>
 				<code>object_id</code>
-				</td>
-				<td>
-					<p>The database ID of the original object this menu item represents, for example the ID for posts or the term_id for categories.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The database ID of the original object this menu item represents, for example the ID for posts or the term_id for categories.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-target">
 			<td>
 				<code>target</code>
-				</td>
-				<td>
-					<p>The target attribute of the link element for this menu item.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The target attribute of the link element for this menu item.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>_blank</code>, <code></code></p>
 							</td>
@@ -159,35 +159,35 @@
 			<tr id="schema-url">
 			<td>
 				<code>url</code>
-				</td>
-				<td>
-					<p>The URL to which this menu item points.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>The URL to which this menu item points.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-xfn">
 			<td>
 				<code>xfn</code>
-				</td>
-				<td>
-					<p>The XFN relationship expressed in the link of this menu item.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>The XFN relationship expressed in the link of this menu item.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-invalid">
 			<td>
 				<code>invalid</code>
-				</td>
-				<td>
-					<p>Whether the menu item represents an object that no longer exists.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether the menu item represents an object that no longer exists.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -195,22 +195,22 @@
 			<tr id="schema-menus">
 			<td>
 				<code>menus</code>
-				</td>
-				<td>
-					<p>The terms assigned to the object in the nav_menu taxonomy.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The terms assigned to the object in the nav_menu taxonomy.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/nav_menus.md
+++ b/reference/nav_menus.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the term.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the term.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
@@ -23,66 +23,66 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>HTML description of the term.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML description of the term.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>HTML title for the term.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML title for the term.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the term unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the term unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-locations">
 			<td>
 				<code>locations</code>
-				</td>
-				<td>
-					<p>The locations assigned to the menu.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>The locations assigned to the menu.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-auto_add">
 			<td>
 				<code>auto_add</code>
-				</td>
-				<td>
-					<p>Whether to automatically add top level pages to this menu.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether to automatically add top level pages to this menu.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/nav_menus.md
+++ b/reference/nav_menus.md
@@ -10,79 +10,79 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the term.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the term.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML description of the term.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>HTML description of the term.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML title for the term.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>HTML title for the term.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the term unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the term unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
-				<code>meta</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Meta fields.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-locations">
 			<td>
-				<code>locations</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>The locations assigned to the menu.</p>
+				<code>locations</code>
+				</td>
+				<td>
+					<p>The locations assigned to the menu.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-auto_add">
 			<td>
-				<code>auto_add</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether to automatically add top level pages to this menu.</p>
+				<code>auto_add</code>
+				</td>
+				<td>
+					<p>Whether to automatically add top level pages to this menu.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/navigation-fallbacks.md
+++ b/reference/navigation-fallbacks.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>The unique identifier for the Navigation Menu.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The unique identifier for the Navigation Menu.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>

--- a/reference/navigation-fallbacks.md
+++ b/reference/navigation-fallbacks.md
@@ -1,0 +1,45 @@
+---
+---
+
+# Navigation Fallbacks
+
+<section class="route">
+	<div class="primary">
+		<h2>Schema</h2>
+<p>The schema defines all the fields that exist within a navigation fallback record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
+<table class="attributes">
+			<tr id="schema-id">
+			<td>
+				<code>id</code>
+				</td>
+				<td>
+					<p>The unique identifier for the Navigation Menu.</p>
+					<p class="type">
+						JSON data type: integer				</p>
+									<p class="read-only">Read only</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
+							</td>
+		</tr>
+	</table>
+
+	</div>
+</section>
+
+<div><section class="route">
+	<div class="primary">
+		<h2>Retrieve a Navigation Fallback</h2>
+
+		<h3>Definition & Example Request</h3>
+
+		<code>GET /wp-block-editor/v1/navigation-fallback</code>
+
+		<p>Query this endpoint to retrieve a specific navigation fallback record.</p>
+
+		<code>$ curl https://example.com/wp-json/wp-block-editor/v1/navigation-fallback</code>
+	</div>
+	<div class="secondary">
+			<p>There are no arguments for this endpoint.</p>
+
+	</div>
+</section>
+</div>

--- a/reference/page-revisions.md
+++ b/reference/page-revisions.md
@@ -10,142 +10,142 @@
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the revision.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the revision was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The globally unique identifier for the post.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>The globally unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the revision.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the revision.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the revision unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The title for the post.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The content for the post.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The content for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-excerpt">
 			<td>
-				<code>excerpt</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The excerpt for the post.</p>
+				<code>excerpt</code>
+				</td>
+				<td>
+					<p>The excerpt for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>

--- a/reference/page-revisions.md
+++ b/reference/page-revisions.md
@@ -11,48 +11,48 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the revision was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>The globally unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The globally unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -60,92 +60,92 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the revision unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The title for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The content for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The content for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-excerpt">
 			<td>
 				<code>excerpt</code>
-				</td>
-				<td>
-					<p>The excerpt for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The excerpt for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>

--- a/reference/pages.md
+++ b/reference/pages.md
@@ -11,37 +11,37 @@
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the post was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>The globally unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The globally unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -49,11 +49,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -61,13 +61,13 @@
 			<tr id="schema-link">
 			<td>
 				<code>link</code>
-				</td>
-				<td>
-					<p>URL to the post.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL to the post.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -75,13 +75,13 @@
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -89,13 +89,13 @@
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -103,22 +103,22 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the post unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>A named status for the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A named status for the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
@@ -126,11 +126,11 @@
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>Type of post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type of post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -138,22 +138,22 @@
 			<tr id="schema-password">
 			<td>
 				<code>password</code>
-				</td>
-				<td>
-					<p>A password to protect access to the content and excerpt.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A password to protect access to the content and excerpt.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-permalink_template">
 			<td>
 				<code>permalink_template</code>
-				</td>
-				<td>
-					<p>Permalink template for the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Permalink template for the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -161,11 +161,11 @@
 			<tr id="schema-generated_slug">
 			<td>
 				<code>generated_slug</code>
-				</td>
-				<td>
-					<p>Slug automatically generated from the post title.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Slug automatically generated from the post title.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -173,77 +173,77 @@
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The title for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The content for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The content for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-excerpt">
 			<td>
 				<code>excerpt</code>
-				</td>
-				<td>
-					<p>The excerpt for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The excerpt for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-featured_media">
 			<td>
 				<code>featured_media</code>
-				</td>
-				<td>
-					<p>The ID of the featured media for the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID of the featured media for the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-comment_status">
 			<td>
 				<code>comment_status</code>
-				</td>
-				<td>
-					<p>Whether or not comments are open on the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Whether or not comments are open on the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
@@ -251,11 +251,11 @@
 			<tr id="schema-ping_status">
 			<td>
 				<code>ping_status</code>
-				</td>
-				<td>
-					<p>Whether or not the post can be pinged.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Whether or not the post can be pinged.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
@@ -263,33 +263,33 @@
 			<tr id="schema-menu_order">
 			<td>
 				<code>menu_order</code>
-				</td>
-				<td>
-					<p>The order of the post in relation to other posts.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The order of the post in relation to other posts.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
 				<code>template</code>
-				</td>
-				<td>
-					<p>The theme file to use to display the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The theme file to use to display the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/pages.md
+++ b/reference/pages.md
@@ -10,286 +10,286 @@
 <table class="attributes">
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the post was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The globally unique identifier for the post.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>The globally unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the post.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
-				<code>link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL to the post.</p>
+				<code>link</code>
+				</td>
+				<td>
+					<p>URL to the post.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the post unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A named status for the post.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>A named status for the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type of post.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>Type of post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-password">
 			<td>
-				<code>password</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A password to protect access to the content and excerpt.</p>
+				<code>password</code>
+				</td>
+				<td>
+					<p>A password to protect access to the content and excerpt.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-permalink_template">
 			<td>
-				<code>permalink_template</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Permalink template for the post.</p>
+				<code>permalink_template</code>
+				</td>
+				<td>
+					<p>Permalink template for the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-generated_slug">
 			<td>
-				<code>generated_slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Slug automatically generated from the post title.</p>
+				<code>generated_slug</code>
+				</td>
+				<td>
+					<p>Slug automatically generated from the post title.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the post.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The title for the post.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The content for the post.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The content for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the post.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-excerpt">
 			<td>
-				<code>excerpt</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The excerpt for the post.</p>
+				<code>excerpt</code>
+				</td>
+				<td>
+					<p>The excerpt for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-featured_media">
 			<td>
-				<code>featured_media</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID of the featured media for the post.</p>
+				<code>featured_media</code>
+				</td>
+				<td>
+					<p>The ID of the featured media for the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-comment_status">
 			<td>
-				<code>comment_status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Whether or not comments are open on the post.</p>
+				<code>comment_status</code>
+				</td>
+				<td>
+					<p>Whether or not comments are open on the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-ping_status">
 			<td>
-				<code>ping_status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Whether or not the post can be pinged.</p>
+				<code>ping_status</code>
+				</td>
+				<td>
+					<p>Whether or not the post can be pinged.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-menu_order">
 			<td>
-				<code>menu_order</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The order of the post in relation to other posts.</p>
+				<code>menu_order</code>
+				</td>
+				<td>
+					<p>The order of the post in relation to other posts.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
-				<code>meta</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Meta fields.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
-				<code>template</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The theme file to use to display the post.</p>
+				<code>template</code>
+				</td>
+				<td>
+					<p>The theme file to use to display the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/pattern-directory-items.md
+++ b/reference/pattern-directory-items.md
@@ -10,89 +10,89 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The pattern ID.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>The pattern ID.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The pattern title, in human readable format.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The pattern title, in human readable format.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The pattern content.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The pattern content.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-categories">
 			<td>
-				<code>categories</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>The pattern&#039;s category slugs.</p>
+				<code>categories</code>
+				</td>
+				<td>
+					<p>The pattern&#039;s category slugs.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-keywords">
 			<td>
-				<code>keywords</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>The pattern&#039;s keywords.</p>
+				<code>keywords</code>
+				</td>
+				<td>
+					<p>The pattern&#039;s keywords.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A description of the pattern.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>A description of the pattern.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-viewport_width">
 			<td>
-				<code>viewport_width</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The preferred width of the viewport when previewing a pattern, in pixels.</p>
+				<code>viewport_width</code>
+				</td>
+				<td>
+					<p>The preferred width of the viewport when previewing a pattern, in pixels.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-block_types">
 			<td>
-				<code>block_types</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>The block types which can use this pattern.</p>
+				<code>block_types</code>
+				</td>
+				<td>
+					<p>The block types which can use this pattern.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 							</td>
 		</tr>

--- a/reference/pattern-directory-items.md
+++ b/reference/pattern-directory-items.md
@@ -11,88 +11,88 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>The pattern ID.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The pattern ID.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The pattern title, in human readable format.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The pattern title, in human readable format.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The pattern content.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The pattern content.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-categories">
 			<td>
 				<code>categories</code>
-				</td>
-				<td>
-					<p>The pattern&#039;s category slugs.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>The pattern&#039;s category slugs.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-keywords">
 			<td>
 				<code>keywords</code>
-				</td>
-				<td>
-					<p>The pattern&#039;s keywords.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>The pattern&#039;s keywords.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>A description of the pattern.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A description of the pattern.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-viewport_width">
 			<td>
 				<code>viewport_width</code>
-				</td>
-				<td>
-					<p>The preferred width of the viewport when previewing a pattern, in pixels.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The preferred width of the viewport when previewing a pattern, in pixels.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-block_types">
 			<td>
 				<code>block_types</code>
-				</td>
-				<td>
-					<p>The block types which can use this pattern.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>The block types which can use this pattern.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 							</td>
 		</tr>

--- a/reference/plugins.md
+++ b/reference/plugins.md
@@ -10,148 +10,148 @@
 <table class="attributes">
 			<tr id="schema-plugin">
 			<td>
-				<code>plugin</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The plugin file.</p>
+				<code>plugin</code>
+				</td>
+				<td>
+					<p>The plugin file.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The plugin activation status.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>The plugin activation status.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>inactive</code>, <code>active</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The plugin name.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The plugin name.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-plugin_uri">
 			<td>
-				<code>plugin_uri</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>The plugin&#039;s website address.</p>
+				<code>plugin_uri</code>
+				</td>
+				<td>
+					<p>The plugin&#039;s website address.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The plugin author.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The plugin author.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_uri">
 			<td>
-				<code>author_uri</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>Plugin author&#039;s website address.</p>
+				<code>author_uri</code>
+				</td>
+				<td>
+					<p>Plugin author&#039;s website address.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The plugin description.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>The plugin description.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-version">
 			<td>
-				<code>version</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The plugin version number.</p>
+				<code>version</code>
+				</td>
+				<td>
+					<p>The plugin version number.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-network_only">
 			<td>
-				<code>network_only</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether the plugin can only be activated network-wide.</p>
+				<code>network_only</code>
+				</td>
+				<td>
+					<p>Whether the plugin can only be activated network-wide.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-requires_wp">
 			<td>
-				<code>requires_wp</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Minimum required version of WordPress.</p>
+				<code>requires_wp</code>
+				</td>
+				<td>
+					<p>Minimum required version of WordPress.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-requires_php">
 			<td>
-				<code>requires_php</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Minimum required version of PHP.</p>
+				<code>requires_php</code>
+				</td>
+				<td>
+					<p>Minimum required version of PHP.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-textdomain">
 			<td>
-				<code>textdomain</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The plugin&#039;s text domain.</p>
+				<code>textdomain</code>
+				</td>
+				<td>
+					<p>The plugin&#039;s text domain.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/plugins.md
+++ b/reference/plugins.md
@@ -11,11 +11,11 @@
 			<tr id="schema-plugin">
 			<td>
 				<code>plugin</code>
-				</td>
-				<td>
-					<p>The plugin file.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The plugin file.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>The plugin activation status.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The plugin activation status.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>inactive</code>, <code>active</code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The plugin name.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The plugin name.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -47,13 +47,13 @@
 			<tr id="schema-plugin_uri">
 			<td>
 				<code>plugin_uri</code>
-				</td>
-				<td>
-					<p>The plugin&#039;s website address.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>The plugin&#039;s website address.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -61,11 +61,11 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The plugin author.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The plugin author.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -73,13 +73,13 @@
 			<tr id="schema-author_uri">
 			<td>
 				<code>author_uri</code>
-				</td>
-				<td>
-					<p>Plugin author&#039;s website address.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>Plugin author&#039;s website address.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -87,11 +87,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>The plugin description.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The plugin description.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -99,11 +99,11 @@
 			<tr id="schema-version">
 			<td>
 				<code>version</code>
-				</td>
-				<td>
-					<p>The plugin version number.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The plugin version number.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -111,11 +111,11 @@
 			<tr id="schema-network_only">
 			<td>
 				<code>network_only</code>
-				</td>
-				<td>
-					<p>Whether the plugin can only be activated network-wide.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether the plugin can only be activated network-wide.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -123,11 +123,11 @@
 			<tr id="schema-requires_wp">
 			<td>
 				<code>requires_wp</code>
-				</td>
-				<td>
-					<p>Minimum required version of WordPress.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Minimum required version of WordPress.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -135,11 +135,11 @@
 			<tr id="schema-requires_php">
 			<td>
 				<code>requires_php</code>
-				</td>
-				<td>
-					<p>Minimum required version of PHP.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Minimum required version of PHP.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -147,11 +147,11 @@
 			<tr id="schema-textdomain">
 			<td>
 				<code>textdomain</code>
-				</td>
-				<td>
-					<p>The plugin&#039;s text domain.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The plugin&#039;s text domain.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/post-revisions.md
+++ b/reference/post-revisions.md
@@ -10,142 +10,142 @@
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the revision.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the revision was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The globally unique identifier for the post.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>The globally unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the revision.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the revision.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the revision unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The title for the post.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The content for the post.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The content for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-excerpt">
 			<td>
-				<code>excerpt</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The excerpt for the post.</p>
+				<code>excerpt</code>
+				</td>
+				<td>
+					<p>The excerpt for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>

--- a/reference/post-revisions.md
+++ b/reference/post-revisions.md
@@ -11,48 +11,48 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the revision was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>The globally unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The globally unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -60,92 +60,92 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the revision unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The title for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The content for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The content for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-excerpt">
 			<td>
 				<code>excerpt</code>
-				</td>
-				<td>
-					<p>The excerpt for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The excerpt for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>

--- a/reference/post-statuses.md
+++ b/reference/post-statuses.md
@@ -10,96 +10,96 @@
 <table class="attributes">
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The title for the status.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The title for the status.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-private">
 			<td>
-				<code>private</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether posts with this status should be private.</p>
+				<code>private</code>
+				</td>
+				<td>
+					<p>Whether posts with this status should be private.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-protected">
 			<td>
-				<code>protected</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether posts with this status should be protected.</p>
+				<code>protected</code>
+				</td>
+				<td>
+					<p>Whether posts with this status should be protected.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-public">
 			<td>
-				<code>public</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether posts of this status should be shown in the front end of the site.</p>
+				<code>public</code>
+				</td>
+				<td>
+					<p>Whether posts of this status should be shown in the front end of the site.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-queryable">
 			<td>
-				<code>queryable</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether posts with this status should be publicly-queryable.</p>
+				<code>queryable</code>
+				</td>
+				<td>
+					<p>Whether posts with this status should be publicly-queryable.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-show_in_list">
 			<td>
-				<code>show_in_list</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether to include posts in the edit listing for their post type.</p>
+				<code>show_in_list</code>
+				</td>
+				<td>
+					<p>Whether to include posts in the edit listing for their post type.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the status.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the status.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_floating">
 			<td>
-				<code>date_floating</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether posts of this status may have floating published dates.</p>
+				<code>date_floating</code>
+				</td>
+				<td>
+					<p>Whether posts of this status may have floating published dates.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/post-statuses.md
+++ b/reference/post-statuses.md
@@ -11,11 +11,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The title for the status.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The title for the status.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-private">
 			<td>
 				<code>private</code>
-				</td>
-				<td>
-					<p>Whether posts with this status should be private.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether posts with this status should be private.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-protected">
 			<td>
 				<code>protected</code>
-				</td>
-				<td>
-					<p>Whether posts with this status should be protected.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether posts with this status should be protected.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -47,11 +47,11 @@
 			<tr id="schema-public">
 			<td>
 				<code>public</code>
-				</td>
-				<td>
-					<p>Whether posts of this status should be shown in the front end of the site.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether posts of this status should be shown in the front end of the site.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -59,11 +59,11 @@
 			<tr id="schema-queryable">
 			<td>
 				<code>queryable</code>
-				</td>
-				<td>
-					<p>Whether posts with this status should be publicly-queryable.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether posts with this status should be publicly-queryable.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -71,11 +71,11 @@
 			<tr id="schema-show_in_list">
 			<td>
 				<code>show_in_list</code>
-				</td>
-				<td>
-					<p>Whether to include posts in the edit listing for their post type.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether to include posts in the edit listing for their post type.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -83,11 +83,11 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the status.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the status.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -95,11 +95,11 @@
 			<tr id="schema-date_floating">
 			<td>
 				<code>date_floating</code>
-				</td>
-				<td>
-					<p>Whether posts of this status may have floating published dates.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether posts of this status may have floating published dates.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/post-types.md
+++ b/reference/post-types.md
@@ -10,168 +10,168 @@
 <table class="attributes">
 			<tr id="schema-capabilities">
 			<td>
-				<code>capabilities</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>All capabilities used by the post type.</p>
+				<code>capabilities</code>
+				</td>
+				<td>
+					<p>All capabilities used by the post type.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A human-readable description of the post type.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>A human-readable description of the post type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-hierarchical">
 			<td>
-				<code>hierarchical</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether or not the post type should have children.</p>
+				<code>hierarchical</code>
+				</td>
+				<td>
+					<p>Whether or not the post type should have children.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-viewable">
 			<td>
-				<code>viewable</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether or not the post type can be viewed.</p>
+				<code>viewable</code>
+				</td>
+				<td>
+					<p>Whether or not the post type can be viewed.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-labels">
 			<td>
-				<code>labels</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Human-readable labels for the post type for various contexts.</p>
+				<code>labels</code>
+				</td>
+				<td>
+					<p>Human-readable labels for the post type for various contexts.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The title for the post type.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The title for the post type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the post type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the post type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-supports">
 			<td>
-				<code>supports</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>All features, supported by the post type.</p>
+				<code>supports</code>
+				</td>
+				<td>
+					<p>All features, supported by the post type.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-has_archive">
 			<td>
-				<code>has_archive</code><br />
-				<span class="type">
-					string or boolean				</span>
-			</td>
-			<td>
-				<p>If the value is a string, the value will be used as the archive slug. If the value is false the post type has no archive.</p>
+				<code>has_archive</code>
+				</td>
+				<td>
+					<p>If the value is a string, the value will be used as the archive slug. If the value is false the post type has no archive.</p>
+					<p class="type">
+						JSON data type: string or boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-taxonomies">
 			<td>
-				<code>taxonomies</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Taxonomies associated with post type.</p>
+				<code>taxonomies</code>
+				</td>
+				<td>
+					<p>Taxonomies associated with post type.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rest_base">
 			<td>
-				<code>rest_base</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>REST base route for the post type.</p>
+				<code>rest_base</code>
+				</td>
+				<td>
+					<p>REST base route for the post type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rest_namespace">
 			<td>
-				<code>rest_namespace</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>REST route&#039;s namespace for the post type.</p>
+				<code>rest_namespace</code>
+				</td>
+				<td>
+					<p>REST route&#039;s namespace for the post type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-visibility">
 			<td>
-				<code>visibility</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The visibility settings for the post type.</p>
+				<code>visibility</code>
+				</td>
+				<td>
+					<p>The visibility settings for the post type.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-icon">
 			<td>
-				<code>icon</code><br />
-				<span class="type">
-					string or null				</span>
-			</td>
-			<td>
-				<p>The icon for the post type.</p>
+				<code>icon</code>
+				</td>
+				<td>
+					<p>The icon for the post type.</p>
+					<p class="type">
+						JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>

--- a/reference/post-types.md
+++ b/reference/post-types.md
@@ -11,11 +11,11 @@
 			<tr id="schema-capabilities">
 			<td>
 				<code>capabilities</code>
-				</td>
-				<td>
-					<p>All capabilities used by the post type.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>All capabilities used by the post type.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>A human-readable description of the post type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A human-readable description of the post type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-hierarchical">
 			<td>
 				<code>hierarchical</code>
-				</td>
-				<td>
-					<p>Whether or not the post type should have children.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether or not the post type should have children.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -47,11 +47,11 @@
 			<tr id="schema-viewable">
 			<td>
 				<code>viewable</code>
-				</td>
-				<td>
-					<p>Whether or not the post type can be viewed.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether or not the post type can be viewed.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -59,11 +59,11 @@
 			<tr id="schema-labels">
 			<td>
 				<code>labels</code>
-				</td>
-				<td>
-					<p>Human-readable labels for the post type for various contexts.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Human-readable labels for the post type for various contexts.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -71,11 +71,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The title for the post type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The title for the post type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -83,11 +83,11 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the post type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the post type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -95,11 +95,11 @@
 			<tr id="schema-supports">
 			<td>
 				<code>supports</code>
-				</td>
-				<td>
-					<p>All features, supported by the post type.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>All features, supported by the post type.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -107,11 +107,11 @@
 			<tr id="schema-has_archive">
 			<td>
 				<code>has_archive</code>
-				</td>
-				<td>
-					<p>If the value is a string, the value will be used as the archive slug. If the value is false the post type has no archive.</p>
-					<p class="type">
-						JSON data type: string or boolean				</p>
+			</td>
+			<td>
+				<p>If the value is a string, the value will be used as the archive slug. If the value is false the post type has no archive.</p>
+				<p class="type">
+					JSON data type: string or boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -119,11 +119,11 @@
 			<tr id="schema-taxonomies">
 			<td>
 				<code>taxonomies</code>
-				</td>
-				<td>
-					<p>Taxonomies associated with post type.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Taxonomies associated with post type.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -131,11 +131,11 @@
 			<tr id="schema-rest_base">
 			<td>
 				<code>rest_base</code>
-				</td>
-				<td>
-					<p>REST base route for the post type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>REST base route for the post type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -143,11 +143,11 @@
 			<tr id="schema-rest_namespace">
 			<td>
 				<code>rest_namespace</code>
-				</td>
-				<td>
-					<p>REST route&#039;s namespace for the post type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>REST route&#039;s namespace for the post type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -155,11 +155,11 @@
 			<tr id="schema-visibility">
 			<td>
 				<code>visibility</code>
-				</td>
-				<td>
-					<p>The visibility settings for the post type.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The visibility settings for the post type.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -167,11 +167,11 @@
 			<tr id="schema-icon">
 			<td>
 				<code>icon</code>
-				</td>
-				<td>
-					<p>The icon for the post type.</p>
-					<p class="type">
-						JSON data type: string or null				</p>
+			</td>
+			<td>
+				<p>The icon for the post type.</p>
+				<p class="type">
+					JSON data type: string or null				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>

--- a/reference/posts.md
+++ b/reference/posts.md
@@ -11,37 +11,37 @@
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the post was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>The globally unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The globally unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -49,11 +49,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -61,13 +61,13 @@
 			<tr id="schema-link">
 			<td>
 				<code>link</code>
-				</td>
-				<td>
-					<p>URL to the post.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL to the post.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -75,13 +75,13 @@
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -89,13 +89,13 @@
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -103,22 +103,22 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the post unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>A named status for the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A named status for the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
@@ -126,11 +126,11 @@
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>Type of post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type of post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -138,22 +138,22 @@
 			<tr id="schema-password">
 			<td>
 				<code>password</code>
-				</td>
-				<td>
-					<p>A password to protect access to the content and excerpt.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A password to protect access to the content and excerpt.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-permalink_template">
 			<td>
 				<code>permalink_template</code>
-				</td>
-				<td>
-					<p>Permalink template for the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Permalink template for the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -161,11 +161,11 @@
 			<tr id="schema-generated_slug">
 			<td>
 				<code>generated_slug</code>
-				</td>
-				<td>
-					<p>Slug automatically generated from the post title.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Slug automatically generated from the post title.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -173,66 +173,66 @@
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The title for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The content for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The content for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-excerpt">
 			<td>
 				<code>excerpt</code>
-				</td>
-				<td>
-					<p>The excerpt for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The excerpt for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-featured_media">
 			<td>
 				<code>featured_media</code>
-				</td>
-				<td>
-					<p>The ID of the featured media for the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID of the featured media for the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-comment_status">
 			<td>
 				<code>comment_status</code>
-				</td>
-				<td>
-					<p>Whether or not comments are open on the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Whether or not comments are open on the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
@@ -240,11 +240,11 @@
 			<tr id="schema-ping_status">
 			<td>
 				<code>ping_status</code>
-				</td>
-				<td>
-					<p>Whether or not the post can be pinged.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Whether or not the post can be pinged.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
@@ -252,11 +252,11 @@
 			<tr id="schema-format">
 			<td>
 				<code>format</code>
-				</td>
-				<td>
-					<p>The format for the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The format for the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>standard</code>, <code>aside</code>, <code>chat</code>, <code>gallery</code>, <code>link</code>, <code>image</code>, <code>quote</code>, <code>status</code>, <code>video</code>, <code>audio</code></p>
 							</td>
@@ -264,55 +264,55 @@
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-sticky">
 			<td>
 				<code>sticky</code>
-				</td>
-				<td>
-					<p>Whether or not the post should be treated as sticky.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether or not the post should be treated as sticky.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
 				<code>template</code>
-				</td>
-				<td>
-					<p>The theme file to use to display the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The theme file to use to display the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-categories">
 			<td>
 				<code>categories</code>
-				</td>
-				<td>
-					<p>The terms assigned to the post in the category taxonomy.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>The terms assigned to the post in the category taxonomy.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-tags">
 			<td>
 				<code>tags</code>
-				</td>
-				<td>
-					<p>The terms assigned to the post in the post_tag taxonomy.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>The terms assigned to the post in the post_tag taxonomy.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/posts.md
+++ b/reference/posts.md
@@ -10,309 +10,309 @@
 <table class="attributes">
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the post was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The globally unique identifier for the post.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>The globally unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the post.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
-				<code>link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL to the post.</p>
+				<code>link</code>
+				</td>
+				<td>
+					<p>URL to the post.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the post unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A named status for the post.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>A named status for the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type of post.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>Type of post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-password">
 			<td>
-				<code>password</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A password to protect access to the content and excerpt.</p>
+				<code>password</code>
+				</td>
+				<td>
+					<p>A password to protect access to the content and excerpt.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-permalink_template">
 			<td>
-				<code>permalink_template</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Permalink template for the post.</p>
+				<code>permalink_template</code>
+				</td>
+				<td>
+					<p>Permalink template for the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-generated_slug">
 			<td>
-				<code>generated_slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Slug automatically generated from the post title.</p>
+				<code>generated_slug</code>
+				</td>
+				<td>
+					<p>Slug automatically generated from the post title.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The title for the post.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The content for the post.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The content for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the post.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-excerpt">
 			<td>
-				<code>excerpt</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The excerpt for the post.</p>
+				<code>excerpt</code>
+				</td>
+				<td>
+					<p>The excerpt for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-featured_media">
 			<td>
-				<code>featured_media</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID of the featured media for the post.</p>
+				<code>featured_media</code>
+				</td>
+				<td>
+					<p>The ID of the featured media for the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-comment_status">
 			<td>
-				<code>comment_status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Whether or not comments are open on the post.</p>
+				<code>comment_status</code>
+				</td>
+				<td>
+					<p>Whether or not comments are open on the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-ping_status">
 			<td>
-				<code>ping_status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Whether or not the post can be pinged.</p>
+				<code>ping_status</code>
+				</td>
+				<td>
+					<p>Whether or not the post can be pinged.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-format">
 			<td>
-				<code>format</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The format for the post.</p>
+				<code>format</code>
+				</td>
+				<td>
+					<p>The format for the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>standard</code>, <code>aside</code>, <code>chat</code>, <code>gallery</code>, <code>link</code>, <code>image</code>, <code>quote</code>, <code>status</code>, <code>video</code>, <code>audio</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
-				<code>meta</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Meta fields.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-sticky">
 			<td>
-				<code>sticky</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether or not the post should be treated as sticky.</p>
+				<code>sticky</code>
+				</td>
+				<td>
+					<p>Whether or not the post should be treated as sticky.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
-				<code>template</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The theme file to use to display the post.</p>
+				<code>template</code>
+				</td>
+				<td>
+					<p>The theme file to use to display the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-categories">
 			<td>
-				<code>categories</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>The terms assigned to the post in the category taxonomy.</p>
+				<code>categories</code>
+				</td>
+				<td>
+					<p>The terms assigned to the post in the category taxonomy.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-tags">
 			<td>
-				<code>tags</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>The terms assigned to the post in the post_tag taxonomy.</p>
+				<code>tags</code>
+				</td>
+				<td>
+					<p>The terms assigned to the post in the post_tag taxonomy.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/rendered-blocks.md
+++ b/reference/rendered-blocks.md
@@ -11,11 +11,11 @@
 			<tr id="schema-rendered">
 			<td>
 				<code>rendered</code>
-				</td>
-				<td>
-					<p>The rendered block.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The rendered block.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/rendered-blocks.md
+++ b/reference/rendered-blocks.md
@@ -10,12 +10,12 @@
 <table class="attributes">
 			<tr id="schema-rendered">
 			<td>
-				<code>rendered</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The rendered block.</p>
+				<code>rendered</code>
+				</td>
+				<td>
+					<p>The rendered block.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/search-results.md
+++ b/reference/search-results.md
@@ -10,50 +10,50 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer or string				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the object.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the object.</p>
+					<p class="type">
+						JSON data type: integer or string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The title for the object.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the object.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-url">
 			<td>
-				<code>url</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL to the object.</p>
+				<code>url</code>
+				</td>
+				<td>
+					<p>URL to the object.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Object type.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>Object type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 									<p>One of: <code>post</code>, <code>term</code>, <code>post-format</code></p>
@@ -61,12 +61,12 @@
 		</tr>
 			<tr id="schema-subtype">
 			<td>
-				<code>subtype</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Object subtype.</p>
+				<code>subtype</code>
+				</td>
+				<td>
+					<p>Object subtype.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 									<p>One of: <code>post</code>, <code>page</code>, <code>category</code>, <code>post_tag</code></p>

--- a/reference/search-results.md
+++ b/reference/search-results.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the object.</p>
-					<p class="type">
-						JSON data type: integer or string				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the object.</p>
+				<p class="type">
+					JSON data type: integer or string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the object.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The title for the object.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 							</td>
@@ -35,13 +35,13 @@
 			<tr id="schema-url">
 			<td>
 				<code>url</code>
-				</td>
-				<td>
-					<p>URL to the object.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL to the object.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 							</td>
@@ -49,11 +49,11 @@
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>Object type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Object type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 									<p>One of: <code>post</code>, <code>term</code>, <code>post-format</code></p>
@@ -62,11 +62,11 @@
 			<tr id="schema-subtype">
 			<td>
 				<code>subtype</code>
-				</td>
-				<td>
-					<p>Object subtype.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Object subtype.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code></p>
 									<p>One of: <code>post</code>, <code>page</code>, <code>category</code>, <code>post_tag</code></p>

--- a/reference/settings.md
+++ b/reference/settings.md
@@ -11,47 +11,47 @@
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>Site title.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Site title.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>Site tagline.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Site tagline.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-url">
 			<td>
 				<code>url</code>
-				</td>
-				<td>
-					<p>Site URL.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>Site URL.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-email">
 			<td>
 				<code>email</code>
-				</td>
-				<td>
-					<p>This address is used for admin purposes, like new user notification.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: email
+			</td>
+			<td>
+				<p>This address is used for admin purposes, like new user notification.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: email
 									</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -59,143 +59,143 @@
 			<tr id="schema-timezone">
 			<td>
 				<code>timezone</code>
-				</td>
-				<td>
-					<p>A city in the same timezone as you.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A city in the same timezone as you.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_format">
 			<td>
 				<code>date_format</code>
-				</td>
-				<td>
-					<p>A date format for all date strings.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A date format for all date strings.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-time_format">
 			<td>
 				<code>time_format</code>
-				</td>
-				<td>
-					<p>A time format for all time strings.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A time format for all time strings.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-start_of_week">
 			<td>
 				<code>start_of_week</code>
-				</td>
-				<td>
-					<p>A day number of the week that the week should start on.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>A day number of the week that the week should start on.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-language">
 			<td>
 				<code>language</code>
-				</td>
-				<td>
-					<p>WordPress locale code.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>WordPress locale code.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-use_smilies">
 			<td>
 				<code>use_smilies</code>
-				</td>
-				<td>
-					<p>Convert emoticons like :-) and :-P to graphics on display.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Convert emoticons like :-) and :-P to graphics on display.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-default_category">
 			<td>
 				<code>default_category</code>
-				</td>
-				<td>
-					<p>Default post category.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Default post category.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-default_post_format">
 			<td>
 				<code>default_post_format</code>
-				</td>
-				<td>
-					<p>Default post format.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Default post format.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-posts_per_page">
 			<td>
 				<code>posts_per_page</code>
-				</td>
-				<td>
-					<p>Blog pages show at most.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Blog pages show at most.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-show_on_front">
 			<td>
 				<code>show_on_front</code>
-				</td>
-				<td>
-					<p>What to show on the front page</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>What to show on the front page</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-page_on_front">
 			<td>
 				<code>page_on_front</code>
-				</td>
-				<td>
-					<p>The ID of the page that should be displayed on the front page</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID of the page that should be displayed on the front page</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-page_for_posts">
 			<td>
 				<code>page_for_posts</code>
-				</td>
-				<td>
-					<p>The ID of the page that should display the latest posts</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID of the page that should display the latest posts</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-default_ping_status">
 			<td>
 				<code>default_ping_status</code>
-				</td>
-				<td>
-					<p>Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
@@ -203,11 +203,11 @@
 			<tr id="schema-default_comment_status">
 			<td>
 				<code>default_comment_status</code>
-				</td>
-				<td>
-					<p>Allow people to submit comments on new posts.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Allow people to submit comments on new posts.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
@@ -215,22 +215,22 @@
 			<tr id="schema-site_logo">
 			<td>
 				<code>site_logo</code>
-				</td>
-				<td>
-					<p>Site logo.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Site logo.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-site_icon">
 			<td>
 				<code>site_icon</code>
-				</td>
-				<td>
-					<p>Site icon.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Site icon.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>

--- a/reference/settings.md
+++ b/reference/settings.md
@@ -10,227 +10,227 @@
 <table class="attributes">
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Site title.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>Site title.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Site tagline.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>Site tagline.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-url">
 			<td>
-				<code>url</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>Site URL.</p>
+				<code>url</code>
+				</td>
+				<td>
+					<p>Site URL.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-email">
 			<td>
-				<code>email</code><br />
-				<span class="type">
-					string,
-													email
-									</span>
-			</td>
-			<td>
-				<p>This address is used for admin purposes, like new user notification.</p>
+				<code>email</code>
+				</td>
+				<td>
+					<p>This address is used for admin purposes, like new user notification.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: email
+									</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-timezone">
 			<td>
-				<code>timezone</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A city in the same timezone as you.</p>
+				<code>timezone</code>
+				</td>
+				<td>
+					<p>A city in the same timezone as you.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_format">
 			<td>
-				<code>date_format</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A date format for all date strings.</p>
+				<code>date_format</code>
+				</td>
+				<td>
+					<p>A date format for all date strings.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-time_format">
 			<td>
-				<code>time_format</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A time format for all time strings.</p>
+				<code>time_format</code>
+				</td>
+				<td>
+					<p>A time format for all time strings.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-start_of_week">
 			<td>
-				<code>start_of_week</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>A day number of the week that the week should start on.</p>
+				<code>start_of_week</code>
+				</td>
+				<td>
+					<p>A day number of the week that the week should start on.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-language">
 			<td>
-				<code>language</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>WordPress locale code.</p>
+				<code>language</code>
+				</td>
+				<td>
+					<p>WordPress locale code.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-use_smilies">
 			<td>
-				<code>use_smilies</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Convert emoticons like :-) and :-P to graphics on display.</p>
+				<code>use_smilies</code>
+				</td>
+				<td>
+					<p>Convert emoticons like :-) and :-P to graphics on display.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-default_category">
 			<td>
-				<code>default_category</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Default post category.</p>
+				<code>default_category</code>
+				</td>
+				<td>
+					<p>Default post category.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-default_post_format">
 			<td>
-				<code>default_post_format</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Default post format.</p>
+				<code>default_post_format</code>
+				</td>
+				<td>
+					<p>Default post format.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-posts_per_page">
 			<td>
-				<code>posts_per_page</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Blog pages show at most.</p>
+				<code>posts_per_page</code>
+				</td>
+				<td>
+					<p>Blog pages show at most.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-show_on_front">
 			<td>
-				<code>show_on_front</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>What to show on the front page</p>
+				<code>show_on_front</code>
+				</td>
+				<td>
+					<p>What to show on the front page</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-page_on_front">
 			<td>
-				<code>page_on_front</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID of the page that should be displayed on the front page</p>
+				<code>page_on_front</code>
+				</td>
+				<td>
+					<p>The ID of the page that should be displayed on the front page</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-page_for_posts">
 			<td>
-				<code>page_for_posts</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID of the page that should display the latest posts</p>
+				<code>page_for_posts</code>
+				</td>
+				<td>
+					<p>The ID of the page that should display the latest posts</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-default_ping_status">
 			<td>
-				<code>default_ping_status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.</p>
+				<code>default_ping_status</code>
+				</td>
+				<td>
+					<p>Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-default_comment_status">
 			<td>
-				<code>default_comment_status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Allow people to submit comments on new posts.</p>
+				<code>default_comment_status</code>
+				</td>
+				<td>
+					<p>Allow people to submit comments on new posts.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 									<p>One of: <code>open</code>, <code>closed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-site_logo">
 			<td>
-				<code>site_logo</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Site logo.</p>
+				<code>site_logo</code>
+				</td>
+				<td>
+					<p>Site logo.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-site_icon">
 			<td>
-				<code>site_icon</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Site icon.</p>
+				<code>site_icon</code>
+				</td>
+				<td>
+					<p>Site icon.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>

--- a/reference/sidebars.md
+++ b/reference/sidebars.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>ID of sidebar.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>ID of sidebar.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>Unique name identifying the sidebar.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Unique name identifying the sidebar.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>Description of sidebar.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Description of sidebar.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -47,11 +47,11 @@
 			<tr id="schema-class">
 			<td>
 				<code>class</code>
-				</td>
-				<td>
-					<p>Extra CSS class to assign to the sidebar in the Widgets interface.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Extra CSS class to assign to the sidebar in the Widgets interface.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -59,11 +59,11 @@
 			<tr id="schema-before_widget">
 			<td>
 				<code>before_widget</code>
-				</td>
-				<td>
-					<p>HTML content to prepend to each widget&#039;s HTML output when assigned to this sidebar. Default is an opening list item element.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML content to prepend to each widget&#039;s HTML output when assigned to this sidebar. Default is an opening list item element.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -71,11 +71,11 @@
 			<tr id="schema-after_widget">
 			<td>
 				<code>after_widget</code>
-				</td>
-				<td>
-					<p>HTML content to append to each widget&#039;s HTML output when assigned to this sidebar. Default is a closing list item element.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML content to append to each widget&#039;s HTML output when assigned to this sidebar. Default is a closing list item element.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -83,11 +83,11 @@
 			<tr id="schema-before_title">
 			<td>
 				<code>before_title</code>
-				</td>
-				<td>
-					<p>HTML content to prepend to the sidebar title when displayed. Default is an opening h2 element.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML content to prepend to the sidebar title when displayed. Default is an opening h2 element.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -95,11 +95,11 @@
 			<tr id="schema-after_title">
 			<td>
 				<code>after_title</code>
-				</td>
-				<td>
-					<p>HTML content to append to the sidebar title when displayed. Default is a closing h2 element.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML content to append to the sidebar title when displayed. Default is a closing h2 element.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -107,11 +107,11 @@
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>Status of sidebar.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Status of sidebar.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>active</code>, <code>inactive</code></p>
@@ -120,11 +120,11 @@
 			<tr id="schema-widgets">
 			<td>
 				<code>widgets</code>
-				</td>
-				<td>
-					<p>Nested widgets.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Nested widgets.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/sidebars.md
+++ b/reference/sidebars.md
@@ -10,108 +10,108 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>ID of sidebar.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>ID of sidebar.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Unique name identifying the sidebar.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>Unique name identifying the sidebar.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Description of sidebar.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>Description of sidebar.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-class">
 			<td>
-				<code>class</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Extra CSS class to assign to the sidebar in the Widgets interface.</p>
+				<code>class</code>
+				</td>
+				<td>
+					<p>Extra CSS class to assign to the sidebar in the Widgets interface.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-before_widget">
 			<td>
-				<code>before_widget</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML content to prepend to each widget&#039;s HTML output when assigned to this sidebar. Default is an opening list item element.</p>
+				<code>before_widget</code>
+				</td>
+				<td>
+					<p>HTML content to prepend to each widget&#039;s HTML output when assigned to this sidebar. Default is an opening list item element.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-after_widget">
 			<td>
-				<code>after_widget</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML content to append to each widget&#039;s HTML output when assigned to this sidebar. Default is a closing list item element.</p>
+				<code>after_widget</code>
+				</td>
+				<td>
+					<p>HTML content to append to each widget&#039;s HTML output when assigned to this sidebar. Default is a closing list item element.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-before_title">
 			<td>
-				<code>before_title</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML content to prepend to the sidebar title when displayed. Default is an opening h2 element.</p>
+				<code>before_title</code>
+				</td>
+				<td>
+					<p>HTML content to prepend to the sidebar title when displayed. Default is an opening h2 element.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-after_title">
 			<td>
-				<code>after_title</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML content to append to the sidebar title when displayed. Default is a closing h2 element.</p>
+				<code>after_title</code>
+				</td>
+				<td>
+					<p>HTML content to append to the sidebar title when displayed. Default is a closing h2 element.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Status of sidebar.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>Status of sidebar.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>active</code>, <code>inactive</code></p>
@@ -119,12 +119,12 @@
 		</tr>
 			<tr id="schema-widgets">
 			<td>
-				<code>widgets</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Nested widgets.</p>
+				<code>widgets</code>
+				</td>
+				<td>
+					<p>Nested widgets.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/tags.md
+++ b/reference/tags.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the term.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the term.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-count">
 			<td>
 				<code>count</code>
-				</td>
-				<td>
-					<p>Number of published posts for the term.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Number of published posts for the term.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -35,24 +35,24 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>HTML description of the term.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML description of the term.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
 				<code>link</code>
-				</td>
-				<td>
-					<p>URL of the term.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL of the term.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
@@ -60,33 +60,33 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>HTML title for the term.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML title for the term.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the term unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the term unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-taxonomy">
 			<td>
 				<code>taxonomy</code>
-				</td>
-				<td>
-					<p>Type attribution for the term.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type attribution for the term.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 									<p>One of: <code>post_tag</code></p>
@@ -95,11 +95,11 @@
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/tags.md
+++ b/reference/tags.md
@@ -10,83 +10,83 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the term.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the term.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-count">
 			<td>
-				<code>count</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Number of published posts for the term.</p>
+				<code>count</code>
+				</td>
+				<td>
+					<p>Number of published posts for the term.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML description of the term.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>HTML description of the term.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
-				<code>link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL of the term.</p>
+				<code>link</code>
+				</td>
+				<td>
+					<p>URL of the term.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML title for the term.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>HTML title for the term.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the term unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the term unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-taxonomy">
 			<td>
-				<code>taxonomy</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type attribution for the term.</p>
+				<code>taxonomy</code>
+				</td>
+				<td>
+					<p>Type attribution for the term.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>embed</code>, <code>edit</code></p>
 									<p>One of: <code>post_tag</code></p>
@@ -94,12 +94,12 @@
 		</tr>
 			<tr id="schema-meta">
 			<td>
-				<code>meta</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Meta fields.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/taxonomies.md
+++ b/reference/taxonomies.md
@@ -11,11 +11,11 @@
 			<tr id="schema-capabilities">
 			<td>
 				<code>capabilities</code>
-				</td>
-				<td>
-					<p>All capabilities used by the taxonomy.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>All capabilities used by the taxonomy.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>A human-readable description of the taxonomy.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A human-readable description of the taxonomy.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-hierarchical">
 			<td>
 				<code>hierarchical</code>
-				</td>
-				<td>
-					<p>Whether or not the taxonomy should have children.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether or not the taxonomy should have children.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -47,11 +47,11 @@
 			<tr id="schema-labels">
 			<td>
 				<code>labels</code>
-				</td>
-				<td>
-					<p>Human-readable labels for the taxonomy for various contexts.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Human-readable labels for the taxonomy for various contexts.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -59,11 +59,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The title for the taxonomy.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The title for the taxonomy.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -71,11 +71,11 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the taxonomy.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the taxonomy.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -83,11 +83,11 @@
 			<tr id="schema-show_cloud">
 			<td>
 				<code>show_cloud</code>
-				</td>
-				<td>
-					<p>Whether or not the term cloud should be displayed.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether or not the term cloud should be displayed.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -95,11 +95,11 @@
 			<tr id="schema-types">
 			<td>
 				<code>types</code>
-				</td>
-				<td>
-					<p>Types associated with the taxonomy.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Types associated with the taxonomy.</p>
+				<p class="type">
+					JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -107,11 +107,11 @@
 			<tr id="schema-rest_base">
 			<td>
 				<code>rest_base</code>
-				</td>
-				<td>
-					<p>REST base route for the taxonomy.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>REST base route for the taxonomy.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -119,11 +119,11 @@
 			<tr id="schema-rest_namespace">
 			<td>
 				<code>rest_namespace</code>
-				</td>
-				<td>
-					<p>REST namespace route for the taxonomy.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>REST namespace route for the taxonomy.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -131,11 +131,11 @@
 			<tr id="schema-visibility">
 			<td>
 				<code>visibility</code>
-				</td>
-				<td>
-					<p>The visibility settings for the taxonomy.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The visibility settings for the taxonomy.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>

--- a/reference/taxonomies.md
+++ b/reference/taxonomies.md
@@ -10,132 +10,132 @@
 <table class="attributes">
 			<tr id="schema-capabilities">
 			<td>
-				<code>capabilities</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>All capabilities used by the taxonomy.</p>
+				<code>capabilities</code>
+				</td>
+				<td>
+					<p>All capabilities used by the taxonomy.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A human-readable description of the taxonomy.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>A human-readable description of the taxonomy.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-hierarchical">
 			<td>
-				<code>hierarchical</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether or not the taxonomy should have children.</p>
+				<code>hierarchical</code>
+				</td>
+				<td>
+					<p>Whether or not the taxonomy should have children.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-labels">
 			<td>
-				<code>labels</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Human-readable labels for the taxonomy for various contexts.</p>
+				<code>labels</code>
+				</td>
+				<td>
+					<p>Human-readable labels for the taxonomy for various contexts.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The title for the taxonomy.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The title for the taxonomy.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the taxonomy.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the taxonomy.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-show_cloud">
 			<td>
-				<code>show_cloud</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether or not the term cloud should be displayed.</p>
+				<code>show_cloud</code>
+				</td>
+				<td>
+					<p>Whether or not the term cloud should be displayed.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-types">
 			<td>
-				<code>types</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Types associated with the taxonomy.</p>
+				<code>types</code>
+				</td>
+				<td>
+					<p>Types associated with the taxonomy.</p>
+					<p class="type">
+						JSON data type: array				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rest_base">
 			<td>
-				<code>rest_base</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>REST base route for the taxonomy.</p>
+				<code>rest_base</code>
+				</td>
+				<td>
+					<p>REST base route for the taxonomy.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rest_namespace">
 			<td>
-				<code>rest_namespace</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>REST namespace route for the taxonomy.</p>
+				<code>rest_namespace</code>
+				</td>
+				<td>
+					<p>REST namespace route for the taxonomy.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-visibility">
 			<td>
-				<code>visibility</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The visibility settings for the taxonomy.</p>
+				<code>visibility</code>
+				</td>
+				<td>
+					<p>The visibility settings for the taxonomy.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>

--- a/reference/themes.md
+++ b/reference/themes.md
@@ -11,11 +11,11 @@
 			<tr id="schema-stylesheet">
 			<td>
 				<code>stylesheet</code>
-				</td>
-				<td>
-					<p>The theme&#039;s stylesheet. This uniquely identifies the theme.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The theme&#039;s stylesheet. This uniquely identifies the theme.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-template">
 			<td>
 				<code>template</code>
-				</td>
-				<td>
-					<p>The theme&#039;s template. If this is a child theme, this refers to the parent theme, otherwise this is the same as the theme&#039;s stylesheet.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The theme&#039;s template. If this is a child theme, this refers to the parent theme, otherwise this is the same as the theme&#039;s stylesheet.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The theme author.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The theme author.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -47,11 +47,11 @@
 			<tr id="schema-author_uri">
 			<td>
 				<code>author_uri</code>
-				</td>
-				<td>
-					<p>The website of the theme author.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The website of the theme author.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -59,11 +59,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>A description of the theme.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>A description of the theme.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -71,11 +71,11 @@
 			<tr id="schema-is_block_theme">
 			<td>
 				<code>is_block_theme</code>
-				</td>
-				<td>
-					<p>Whether the theme is a block-based theme.</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether the theme is a block-based theme.</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -83,11 +83,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>The name of the theme.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The name of the theme.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -95,11 +95,11 @@
 			<tr id="schema-requires_php">
 			<td>
 				<code>requires_php</code>
-				</td>
-				<td>
-					<p>The minimum PHP version required for the theme to work.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The minimum PHP version required for the theme to work.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -107,11 +107,11 @@
 			<tr id="schema-requires_wp">
 			<td>
 				<code>requires_wp</code>
-				</td>
-				<td>
-					<p>The minimum WordPress version required for the theme to work.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The minimum WordPress version required for the theme to work.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -119,13 +119,13 @@
 			<tr id="schema-screenshot">
 			<td>
 				<code>screenshot</code>
-				</td>
-				<td>
-					<p>The theme&#039;s screenshot URL.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>The theme&#039;s screenshot URL.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -133,11 +133,11 @@
 			<tr id="schema-tags">
 			<td>
 				<code>tags</code>
-				</td>
-				<td>
-					<p>Tags indicating styles and features of the theme.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Tags indicating styles and features of the theme.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -145,11 +145,11 @@
 			<tr id="schema-textdomain">
 			<td>
 				<code>textdomain</code>
-				</td>
-				<td>
-					<p>The theme&#039;s text domain.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The theme&#039;s text domain.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -157,11 +157,11 @@
 			<tr id="schema-theme_supports">
 			<td>
 				<code>theme_supports</code>
-				</td>
-				<td>
-					<p>Features supported by this theme.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Features supported by this theme.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -169,11 +169,11 @@
 			<tr id="schema-theme_uri">
 			<td>
 				<code>theme_uri</code>
-				</td>
-				<td>
-					<p>The URI of the theme&#039;s webpage.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The URI of the theme&#039;s webpage.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -181,11 +181,11 @@
 			<tr id="schema-version">
 			<td>
 				<code>version</code>
-				</td>
-				<td>
-					<p>The theme&#039;s current version.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The theme&#039;s current version.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -193,11 +193,11 @@
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>A named status for the theme.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A named status for the theme.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 									<p>One of: <code>inactive</code>, <code>active</code></p>
 							</td>

--- a/reference/themes.md
+++ b/reference/themes.md
@@ -10,182 +10,194 @@
 <table class="attributes">
 			<tr id="schema-stylesheet">
 			<td>
-				<code>stylesheet</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The theme&#039;s stylesheet. This uniquely identifies the theme.</p>
+				<code>stylesheet</code>
+				</td>
+				<td>
+					<p>The theme&#039;s stylesheet. This uniquely identifies the theme.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
-				<code>template</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The theme&#039;s template. If this is a child theme, this refers to the parent theme, otherwise this is the same as the theme&#039;s stylesheet.</p>
+				<code>template</code>
+				</td>
+				<td>
+					<p>The theme&#039;s template. If this is a child theme, this refers to the parent theme, otherwise this is the same as the theme&#039;s stylesheet.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The theme author.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The theme author.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-author_uri">
 			<td>
-				<code>author_uri</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The website of the theme author.</p>
+				<code>author_uri</code>
+				</td>
+				<td>
+					<p>The website of the theme author.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					object				</span>
-			</td>
+				<code>description</code>
+				</td>
+				<td>
+					<p>A description of the theme.</p>
+					<p class="type">
+						JSON data type: object				</p>
+									<p class="read-only">Read only</p>
+								<p class="context">Context: <code></code></p>
+							</td>
+		</tr>
+			<tr id="schema-is_block_theme">
 			<td>
-				<p>A description of the theme.</p>
+				<code>is_block_theme</code>
+				</td>
+				<td>
+					<p>Whether the theme is a block-based theme.</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The name of the theme.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>The name of the theme.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-requires_php">
 			<td>
-				<code>requires_php</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The minimum PHP version required for the theme to work.</p>
+				<code>requires_php</code>
+				</td>
+				<td>
+					<p>The minimum PHP version required for the theme to work.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-requires_wp">
 			<td>
-				<code>requires_wp</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The minimum WordPress version required for the theme to work.</p>
+				<code>requires_wp</code>
+				</td>
+				<td>
+					<p>The minimum WordPress version required for the theme to work.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-screenshot">
 			<td>
-				<code>screenshot</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>The theme&#039;s screenshot URL.</p>
+				<code>screenshot</code>
+				</td>
+				<td>
+					<p>The theme&#039;s screenshot URL.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-tags">
 			<td>
-				<code>tags</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Tags indicating styles and features of the theme.</p>
+				<code>tags</code>
+				</td>
+				<td>
+					<p>Tags indicating styles and features of the theme.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-textdomain">
 			<td>
-				<code>textdomain</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The theme&#039;s text domain.</p>
+				<code>textdomain</code>
+				</td>
+				<td>
+					<p>The theme&#039;s text domain.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-theme_supports">
 			<td>
-				<code>theme_supports</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Features supported by this theme.</p>
+				<code>theme_supports</code>
+				</td>
+				<td>
+					<p>Features supported by this theme.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-theme_uri">
 			<td>
-				<code>theme_uri</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The URI of the theme&#039;s webpage.</p>
+				<code>theme_uri</code>
+				</td>
+				<td>
+					<p>The URI of the theme&#039;s webpage.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-version">
 			<td>
-				<code>version</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The theme&#039;s current version.</p>
+				<code>version</code>
+				</td>
+				<td>
+					<p>The theme&#039;s current version.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A named status for the theme.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>A named status for the theme.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 									<p>One of: <code>inactive</code>, <code>active</code></p>
 							</td>

--- a/reference/users.md
+++ b/reference/users.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the user.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the user.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -23,56 +23,56 @@
 			<tr id="schema-username">
 			<td>
 				<code>username</code>
-				</td>
-				<td>
-					<p>Login name for the user.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Login name for the user.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>Display name for the user.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Display name for the user.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-first_name">
 			<td>
 				<code>first_name</code>
-				</td>
-				<td>
-					<p>First name for the user.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>First name for the user.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-last_name">
 			<td>
 				<code>last_name</code>
-				</td>
-				<td>
-					<p>Last name for the user.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Last name for the user.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-email">
 			<td>
 				<code>email</code>
-				</td>
-				<td>
-					<p>The email address for the user.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: email
+			</td>
+			<td>
+				<p>The email address for the user.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: email
 									</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -80,37 +80,37 @@
 			<tr id="schema-url">
 			<td>
 				<code>url</code>
-				</td>
-				<td>
-					<p>URL of the user.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL of the user.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>Description of the user.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Description of the user.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
 				<code>link</code>
-				</td>
-				<td>
-					<p>Author URL of the user.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>Author URL of the user.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -118,11 +118,11 @@
 			<tr id="schema-locale">
 			<td>
 				<code>locale</code>
-				</td>
-				<td>
-					<p>Locale for the user.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Locale for the user.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 									<p>One of: <code></code>, <code>en_US</code></p>
 							</td>
@@ -130,35 +130,35 @@
 			<tr id="schema-nickname">
 			<td>
 				<code>nickname</code>
-				</td>
-				<td>
-					<p>The nickname for the user.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The nickname for the user.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the user.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the user.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-registered_date">
 			<td>
 				<code>registered_date</code>
-				</td>
-				<td>
-					<p>Registration date for the user.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>Registration date for the user.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -166,33 +166,33 @@
 			<tr id="schema-roles">
 			<td>
 				<code>roles</code>
-				</td>
-				<td>
-					<p>Roles assigned to the user.</p>
-					<p class="type">
-						JSON data type: array				</p>
+			</td>
+			<td>
+				<p>Roles assigned to the user.</p>
+				<p class="type">
+					JSON data type: array				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-password">
 			<td>
 				<code>password</code>
-				</td>
-				<td>
-					<p>Password for the user (never included).</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Password for the user (never included).</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-capabilities">
 			<td>
 				<code>capabilities</code>
-				</td>
-				<td>
-					<p>All capabilities assigned to the user.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>All capabilities assigned to the user.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -200,11 +200,11 @@
 			<tr id="schema-extra_capabilities">
 			<td>
 				<code>extra_capabilities</code>
-				</td>
-				<td>
-					<p>Any extra capabilities assigned to the user.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Any extra capabilities assigned to the user.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -212,11 +212,11 @@
 			<tr id="schema-avatar_urls">
 			<td>
 				<code>avatar_urls</code>
-				</td>
-				<td>
-					<p>Avatar URLs for the user.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Avatar URLs for the user.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -224,11 +224,11 @@
 			<tr id="schema-meta">
 			<td>
 				<code>meta</code>
-				</td>
-				<td>
-					<p>Meta fields.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Meta fields.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/users.md
+++ b/reference/users.md
@@ -10,225 +10,225 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the user.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the user.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-username">
 			<td>
-				<code>username</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Login name for the user.</p>
+				<code>username</code>
+				</td>
+				<td>
+					<p>Login name for the user.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Display name for the user.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>Display name for the user.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-first_name">
 			<td>
-				<code>first_name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>First name for the user.</p>
+				<code>first_name</code>
+				</td>
+				<td>
+					<p>First name for the user.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-last_name">
 			<td>
-				<code>last_name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Last name for the user.</p>
+				<code>last_name</code>
+				</td>
+				<td>
+					<p>Last name for the user.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-email">
 			<td>
-				<code>email</code><br />
-				<span class="type">
-					string,
-													email
-									</span>
-			</td>
-			<td>
-				<p>The email address for the user.</p>
+				<code>email</code>
+				</td>
+				<td>
+					<p>The email address for the user.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: email
+									</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-url">
 			<td>
-				<code>url</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL of the user.</p>
+				<code>url</code>
+				</td>
+				<td>
+					<p>URL of the user.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Description of the user.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>Description of the user.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
-				<code>link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>Author URL of the user.</p>
+				<code>link</code>
+				</td>
+				<td>
+					<p>Author URL of the user.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-locale">
 			<td>
-				<code>locale</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Locale for the user.</p>
+				<code>locale</code>
+				</td>
+				<td>
+					<p>Locale for the user.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
-									<p>One of: <code></code>, <code>en_US</code>, <code>de_DE</code></p>
+									<p>One of: <code></code>, <code>en_US</code></p>
 							</td>
 		</tr>
 			<tr id="schema-nickname">
 			<td>
-				<code>nickname</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The nickname for the user.</p>
+				<code>nickname</code>
+				</td>
+				<td>
+					<p>The nickname for the user.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the user.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the user.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-registered_date">
 			<td>
-				<code>registered_date</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>Registration date for the user.</p>
+				<code>registered_date</code>
+				</td>
+				<td>
+					<p>Registration date for the user.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-roles">
 			<td>
-				<code>roles</code><br />
-				<span class="type">
-					array				</span>
-			</td>
-			<td>
-				<p>Roles assigned to the user.</p>
+				<code>roles</code>
+				</td>
+				<td>
+					<p>Roles assigned to the user.</p>
+					<p class="type">
+						JSON data type: array				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-password">
 			<td>
-				<code>password</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Password for the user (never included).</p>
+				<code>password</code>
+				</td>
+				<td>
+					<p>Password for the user (never included).</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-capabilities">
 			<td>
-				<code>capabilities</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>All capabilities assigned to the user.</p>
+				<code>capabilities</code>
+				</td>
+				<td>
+					<p>All capabilities assigned to the user.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-extra_capabilities">
 			<td>
-				<code>extra_capabilities</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Any extra capabilities assigned to the user.</p>
+				<code>extra_capabilities</code>
+				</td>
+				<td>
+					<p>Any extra capabilities assigned to the user.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-avatar_urls">
 			<td>
-				<code>avatar_urls</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Avatar URLs for the user.</p>
+				<code>avatar_urls</code>
+				</td>
+				<td>
+					<p>Avatar URLs for the user.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-meta">
 			<td>
-				<code>meta</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Meta fields.</p>
+				<code>meta</code>
+				</td>
+				<td>
+					<p>Meta fields.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
@@ -461,7 +461,7 @@
 									</td>
 				<td>
 											<p>Locale for the user.</p>
-																										<p>One of: <code></code>, <code>en_US</code>, <code>de_DE</code></p>
+																										<p>One of: <code></code>, <code>en_US</code></p>
 									</td>
 			</tr>
 					<tr>
@@ -630,7 +630,7 @@
 									</td>
 				<td>
 											<p>Locale for the user.</p>
-																										<p>One of: <code></code>, <code>en_US</code>, <code>de_DE</code></p>
+																										<p>One of: <code></code>, <code>en_US</code></p>
 									</td>
 			</tr>
 					<tr>
@@ -829,7 +829,7 @@
 									</td>
 				<td>
 											<p>Locale for the user.</p>
-																										<p>One of: <code></code>, <code>en_US</code>, <code>de_DE</code></p>
+																										<p>One of: <code></code>, <code>en_US</code></p>
 									</td>
 			</tr>
 					<tr>

--- a/reference/widget-types.md
+++ b/reference/widget-types.md
@@ -10,59 +10,59 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Unique slug identifying the widget type.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique slug identifying the widget type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-name">
 			<td>
-				<code>name</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Human-readable name identifying the widget type.</p>
+				<code>name</code>
+				</td>
+				<td>
+					<p>Human-readable name identifying the widget type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Description of the widget.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>Description of the widget.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-is_multi">
 			<td>
-				<code>is_multi</code><br />
-				<span class="type">
-					boolean				</span>
-			</td>
-			<td>
-				<p>Whether the widget supports multiple instances</p>
+				<code>is_multi</code>
+				</td>
+				<td>
+					<p>Whether the widget supports multiple instances</p>
+					<p class="type">
+						JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-classname">
 			<td>
-				<code>classname</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Class name</p>
+				<code>classname</code>
+				</td>
+				<td>
+					<p>Class name</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/widget-types.md
+++ b/reference/widget-types.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique slug identifying the widget type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Unique slug identifying the widget type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-name">
 			<td>
 				<code>name</code>
-				</td>
-				<td>
-					<p>Human-readable name identifying the widget type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Human-readable name identifying the widget type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -35,22 +35,22 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>Description of the widget.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Description of the widget.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-is_multi">
 			<td>
 				<code>is_multi</code>
-				</td>
-				<td>
-					<p>Whether the widget supports multiple instances</p>
-					<p class="type">
-						JSON data type: boolean				</p>
+			</td>
+			<td>
+				<p>Whether the widget supports multiple instances</p>
+				<p class="type">
+					JSON data type: boolean				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -58,11 +58,11 @@
 			<tr id="schema-classname">
 			<td>
 				<code>classname</code>
-				</td>
-				<td>
-					<p>Class name</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Class name</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/widgets.md
+++ b/reference/widgets.md
@@ -10,80 +10,80 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the widget.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the widget.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id_base">
 			<td>
-				<code>id_base</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The type of the widget. Corresponds to ID in widget-types endpoint.</p>
+				<code>id_base</code>
+				</td>
+				<td>
+					<p>The type of the widget. Corresponds to ID in widget-types endpoint.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-sidebar">
 			<td>
-				<code>sidebar</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The sidebar the widget belongs to.</p>
+				<code>sidebar</code>
+				</td>
+				<td>
+					<p>The sidebar the widget belongs to.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rendered">
 			<td>
-				<code>rendered</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML representation of the widget.</p>
+				<code>rendered</code>
+				</td>
+				<td>
+					<p>HTML representation of the widget.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rendered_form">
 			<td>
-				<code>rendered_form</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML representation of the widget admin form.</p>
+				<code>rendered_form</code>
+				</td>
+				<td>
+					<p>HTML representation of the widget admin form.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-instance">
 			<td>
-				<code>instance</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Instance settings of the widget, if supported.</p>
+				<code>instance</code>
+				</td>
+				<td>
+					<p>Instance settings of the widget, if supported.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-form_data">
 			<td>
-				<code>form_data</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>URL-encoded form data from the widget admin form. Used to update a widget that does not support instance. Write only.</p>
+				<code>form_data</code>
+				</td>
+				<td>
+					<p>URL-encoded form data from the widget admin form. Used to update a widget that does not support instance. Write only.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>

--- a/reference/widgets.md
+++ b/reference/widgets.md
@@ -11,44 +11,44 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the widget.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the widget.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id_base">
 			<td>
 				<code>id_base</code>
-				</td>
-				<td>
-					<p>The type of the widget. Corresponds to ID in widget-types endpoint.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The type of the widget. Corresponds to ID in widget-types endpoint.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-sidebar">
 			<td>
 				<code>sidebar</code>
-				</td>
-				<td>
-					<p>The sidebar the widget belongs to.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The sidebar the widget belongs to.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-rendered">
 			<td>
 				<code>rendered</code>
-				</td>
-				<td>
-					<p>HTML representation of the widget.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML representation of the widget.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -56,11 +56,11 @@
 			<tr id="schema-rendered_form">
 			<td>
 				<code>rendered_form</code>
-				</td>
-				<td>
-					<p>HTML representation of the widget admin form.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML representation of the widget admin form.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
@@ -68,22 +68,22 @@
 			<tr id="schema-instance">
 			<td>
 				<code>instance</code>
-				</td>
-				<td>
-					<p>Instance settings of the widget, if supported.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Instance settings of the widget, if supported.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-form_data">
 			<td>
 				<code>form_data</code>
-				</td>
-				<td>
-					<p>URL-encoded form data from the widget admin form. Used to update a widget that does not support instance. Write only.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>URL-encoded form data from the widget admin form. Used to update a widget that does not support instance. Write only.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>

--- a/reference/wp-site-health-tests.md
+++ b/reference/wp-site-health-tests.md
@@ -11,11 +11,11 @@
 			<tr id="schema-test">
 			<td>
 				<code>test</code>
-				</td>
-				<td>
-					<p>The name of the test being run.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The name of the test being run.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -23,11 +23,11 @@
 			<tr id="schema-label">
 			<td>
 				<code>label</code>
-				</td>
-				<td>
-					<p>A label describing the test.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A label describing the test.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -35,11 +35,11 @@
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>The status of the test.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The status of the test.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 									<p>One of: <code>good</code>, <code>recommended</code>, <code>critical</code></p>
@@ -48,11 +48,11 @@
 			<tr id="schema-badge">
 			<td>
 				<code>badge</code>
-				</td>
-				<td>
-					<p>The category this test is grouped in.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The category this test is grouped in.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -60,11 +60,11 @@
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>A more descriptive explanation of what the test looks for, and why it is important for the user.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A more descriptive explanation of what the test looks for, and why it is important for the user.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
@@ -72,11 +72,11 @@
 			<tr id="schema-actions">
 			<td>
 				<code>actions</code>
-				</td>
-				<td>
-					<p>HTML containing an action to direct the user to where they can resolve the issue.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>HTML containing an action to direct the user to where they can resolve the issue.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>

--- a/reference/wp-site-health-tests.md
+++ b/reference/wp-site-health-tests.md
@@ -10,36 +10,36 @@
 <table class="attributes">
 			<tr id="schema-test">
 			<td>
-				<code>test</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The name of the test being run.</p>
+				<code>test</code>
+				</td>
+				<td>
+					<p>The name of the test being run.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-label">
 			<td>
-				<code>label</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A label describing the test.</p>
+				<code>label</code>
+				</td>
+				<td>
+					<p>A label describing the test.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The status of the test.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>The status of the test.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 									<p>One of: <code>good</code>, <code>recommended</code>, <code>critical</code></p>
@@ -47,36 +47,36 @@
 		</tr>
 			<tr id="schema-badge">
 			<td>
-				<code>badge</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The category this test is grouped in.</p>
+				<code>badge</code>
+				</td>
+				<td>
+					<p>The category this test is grouped in.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A more descriptive explanation of what the test looks for, and why it is important for the user.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>A more descriptive explanation of what the test looks for, and why it is important for the user.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>
 		</tr>
 			<tr id="schema-actions">
 			<td>
-				<code>actions</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>HTML containing an action to direct the user to where they can resolve the issue.</p>
+				<code>actions</code>
+				</td>
+				<td>
+					<p>HTML containing an action to direct the user to where they can resolve the issue.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code></code></p>
 							</td>

--- a/reference/wp_global_styles-revisions.md
+++ b/reference/wp_global_styles-revisions.md
@@ -11,107 +11,107 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the revision was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-styles">
 			<td>
 				<code>styles</code>
-				</td>
-				<td>
-					<p>Global styles.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Global styles.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-settings">
 			<td>
 				<code>settings</code>
-				</td>
-				<td>
-					<p>Global settings.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Global settings.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_global_styles-revisions.md
+++ b/reference/wp_global_styles-revisions.md
@@ -1,0 +1,190 @@
+---
+---
+
+# Global_Styles Revisions
+
+<section class="route">
+	<div class="primary">
+		<h2>Schema</h2>
+<p>The schema defines all the fields that exist within a global_styles revision record. Any response from these endpoints can be expected to contain the fields below unless the `_filter` query parameter is used or the schema field only appears in a specific context.</p>
+<table class="attributes">
+			<tr id="schema-author">
+			<td>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
+							</td>
+		</tr>
+			<tr id="schema-date">
+			<td>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the revision was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
+							</td>
+		</tr>
+			<tr id="schema-date_gmt">
+			<td>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+							</td>
+		</tr>
+			<tr id="schema-id">
+			<td>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
+							</td>
+		</tr>
+			<tr id="schema-modified">
+			<td>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+							</td>
+		</tr>
+			<tr id="schema-modified_gmt">
+			<td>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+							</td>
+		</tr>
+			<tr id="schema-parent">
+			<td>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
+							</td>
+		</tr>
+			<tr id="schema-styles">
+			<td>
+				<code>styles</code>
+				</td>
+				<td>
+					<p>Global styles.</p>
+					<p class="type">
+						JSON data type: object				</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+							</td>
+		</tr>
+			<tr id="schema-settings">
+			<td>
+				<code>settings</code>
+				</td>
+				<td>
+					<p>Global settings.</p>
+					<p class="type">
+						JSON data type: object				</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+							</td>
+		</tr>
+	</table>
+
+	</div>
+</section>
+
+<div><section class="route">
+	<div class="primary">
+		<h2>List Global_Styles Revisions</h2>
+		<p>Query this endpoint to retrieve a collection of global_styles revisions. The response you receive can be controlled and filtered using the URL query parameters below.</p>
+
+		<h3>Definition</h3>
+
+		<code>GET /wp/v2/global-styles/&lt;parent&gt;/revisions</code>
+
+		<h3>Example Request</h3>
+
+		<code>$ curl https://example.com/wp-json/wp/v2/global-styles/&lt;parent&gt;/revisions</code>
+	</div>
+	<div class="secondary">
+			<h3>Arguments</h3>
+	<table class="arguments">
+					<tr>
+				<td>
+											<code>parent</code><br />
+									</td>
+				<td>
+											<p>The ID for the parent of the revision.</p>
+																								</td>
+			</tr>
+					<tr>
+				<td>
+											<code>context</code><br />
+									</td>
+				<td>
+											<p>Scope under which the request is made; determines fields present in response.</p>
+																					<p class="default">
+							Default: <code>view</code>
+						</p>
+																<p>One of: <code>view</code>, <code>embed</code>, <code>edit</code></p>
+									</td>
+			</tr>
+					<tr>
+				<td>
+											<code>page</code><br />
+									</td>
+				<td>
+											<p>Current page of the collection.</p>
+																					<p class="default">
+							Default: <code>1</code>
+						</p>
+														</td>
+			</tr>
+					<tr>
+				<td>
+											<code>per_page</code><br />
+									</td>
+				<td>
+											<p>Maximum number of items to be returned in result set.</p>
+																								</td>
+			</tr>
+					<tr>
+				<td>
+											<code>offset</code><br />
+									</td>
+				<td>
+											<p>Offset the result set by a specific number of items.</p>
+																								</td>
+			</tr>
+			</table>
+
+	</div>
+</section>
+</div>

--- a/reference/wp_global_styles.md
+++ b/reference/wp_global_styles.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>ID of global styles config.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>ID of global styles config.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -23,33 +23,33 @@
 			<tr id="schema-styles">
 			<td>
 				<code>styles</code>
-				</td>
-				<td>
-					<p>Global styles.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Global styles.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-settings">
 			<td>
 				<code>settings</code>
-				</td>
-				<td>
-					<p>Global settings.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>Global settings.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>Title of the global styles variation.</p>
-					<p class="type">
-						JSON data type: object or string				</p>
+			</td>
+			<td>
+				<p>Title of the global styles variation.</p>
+				<p class="type">
+					JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_global_styles.md
+++ b/reference/wp_global_styles.md
@@ -10,46 +10,46 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>ID of global styles config.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>ID of global styles config.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-styles">
 			<td>
-				<code>styles</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Global styles.</p>
+				<code>styles</code>
+				</td>
+				<td>
+					<p>Global styles.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-settings">
 			<td>
-				<code>settings</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>Global settings.</p>
+				<code>settings</code>
+				</td>
+				<td>
+					<p>Global settings.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object or string				</span>
-			</td>
-			<td>
-				<p>Title of the global styles variation.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>Title of the global styles variation.</p>
+					<p class="type">
+						JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_navigation-revisions.md
+++ b/reference/wp_navigation-revisions.md
@@ -10,132 +10,132 @@
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the revision.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the revision was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The globally unique identifier for the post.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>The globally unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the revision.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the revision.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the revision unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The title for the post.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The content for the post.</p>
-								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The content for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 	</table>

--- a/reference/wp_navigation-revisions.md
+++ b/reference/wp_navigation-revisions.md
@@ -11,48 +11,48 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the revision was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>The globally unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The globally unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -60,81 +60,81 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the revision unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The title for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The content for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The content for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>

--- a/reference/wp_navigations.md
+++ b/reference/wp_navigations.md
@@ -11,37 +11,37 @@
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the post was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string or null,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string or null,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>The globally unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The globally unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -49,11 +49,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the post.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the post.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -61,13 +61,13 @@
 			<tr id="schema-link">
 			<td>
 				<code>link</code>
-				</td>
-				<td>
-					<p>URL to the post.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: uri
-										</p>
+			</td>
+			<td>
+				<p>URL to the post.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: uri
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -75,13 +75,13 @@
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -89,13 +89,13 @@
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the post was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the post was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -103,22 +103,22 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the post unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>A named status for the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A named status for the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
@@ -126,11 +126,11 @@
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>Type of post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type of post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
@@ -138,44 +138,44 @@
 			<tr id="schema-password">
 			<td>
 				<code>password</code>
-				</td>
-				<td>
-					<p>A password to protect access to the content and excerpt.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>A password to protect access to the content and excerpt.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>The title for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The title for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>The content for the post.</p>
-					<p class="type">
-						JSON data type: object				</p>
+			</td>
+			<td>
+				<p>The content for the post.</p>
+				<p class="type">
+					JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
 				<code>template</code>
-				</td>
-				<td>
-					<p>The theme file to use to display the post.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>The theme file to use to display the post.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_navigations.md
+++ b/reference/wp_navigations.md
@@ -10,172 +10,172 @@
 <table class="attributes">
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the post was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string or null,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string or null,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The globally unique identifier for the post.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>The globally unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the post.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the post.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-link">
 			<td>
-				<code>link</code><br />
-				<span class="type">
-					string,
-													uri
-										</span>
-			</td>
-			<td>
-				<p>URL to the post.</p>
+				<code>link</code>
+				</td>
+				<td>
+					<p>URL to the post.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: uri
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the post was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the post was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the post unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the post unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A named status for the post.</p>
-								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>A named status for the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type of post.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>Type of post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-password">
 			<td>
-				<code>password</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>A password to protect access to the content and excerpt.</p>
+				<code>password</code>
+				</td>
+				<td>
+					<p>A password to protect access to the content and excerpt.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The title for the post.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>The title for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object				</span>
-			</td>
-			<td>
-				<p>The content for the post.</p>
-								<p class="context">Context: <code>view</code>, <code>edit</code></p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>The content for the post.</p>
+					<p class="type">
+						JSON data type: object				</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-template">
 			<td>
-				<code>template</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>The theme file to use to display the post.</p>
+				<code>template</code>
+				</td>
+				<td>
+					<p>The theme file to use to display the post.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_template-revisions.md
+++ b/reference/wp_template-revisions.md
@@ -11,129 +11,129 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the revision was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>GUID for the revision, as it exists in the database.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>GUID for the revision, as it exists in the database.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the revision unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>Title of template.</p>
-					<p class="type">
-						JSON data type: object or string				</p>
+			</td>
+			<td>
+				<p>Title of template.</p>
+				<p class="type">
+					JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>Content of template.</p>
-					<p class="type">
-						JSON data type: object or string				</p>
+			</td>
+			<td>
+				<p>Content of template.</p>
+				<p class="type">
+					JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_template-revisions.md
+++ b/reference/wp_template-revisions.md
@@ -10,130 +10,130 @@
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the revision.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the revision was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>GUID for the revision, as it exists in the database.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>GUID for the revision, as it exists in the database.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the revision.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the revision.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the revision unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object or string				</span>
-			</td>
-			<td>
-				<p>Title of template.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>Title of template.</p>
+					<p class="type">
+						JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object or string				</span>
-			</td>
-			<td>
-				<p>Content of template.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>Content of template.</p>
+					<p class="type">
+						JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_template_part-revisions.md
+++ b/reference/wp_template_part-revisions.md
@@ -11,129 +11,129 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
 				<code>date</code>
-				</td>
-				<td>
-					<p>The date the revision was published, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
 				<code>date_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was published, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was published, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
 				<code>guid</code>
-				</td>
-				<td>
-					<p>GUID for the revision, as it exists in the database.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>GUID for the revision, as it exists in the database.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>Unique identifier for the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Unique identifier for the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
 				<code>modified_gmt</code>
-				</td>
-				<td>
-					<p>The date the revision was last modified, as GMT.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the revision was last modified, as GMT.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
 				<code>parent</code>
-				</td>
-				<td>
-					<p>The ID for the parent of the revision.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the parent of the revision.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>An alphanumeric identifier for the revision unique to its type.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>Title of template.</p>
-					<p class="type">
-						JSON data type: object or string				</p>
+			</td>
+			<td>
+				<p>Title of template.</p>
+				<p class="type">
+					JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>Content of template.</p>
-					<p class="type">
-						JSON data type: object or string				</p>
+			</td>
+			<td>
+				<p>Content of template.</p>
+				<p class="type">
+					JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_template_part-revisions.md
+++ b/reference/wp_template_part-revisions.md
@@ -10,130 +10,130 @@
 <table class="attributes">
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the revision.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date">
 			<td>
-				<code>date</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, in the site&#039;s timezone.</p>
+				<code>date</code>
+				</td>
+				<td>
+					<p>The date the revision was published, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-date_gmt">
 			<td>
-				<code>date_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was published, as GMT.</p>
+				<code>date_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was published, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-guid">
 			<td>
-				<code>guid</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>GUID for the revision, as it exists in the database.</p>
+				<code>guid</code>
+				</td>
+				<td>
+					<p>GUID for the revision, as it exists in the database.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Unique identifier for the revision.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>Unique identifier for the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
-				<code>modified</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified_gmt">
 			<td>
-				<code>modified_gmt</code><br />
-				<span class="type">
-					string,
-													datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</span>
-			</td>
-			<td>
-				<p>The date the revision was last modified, as GMT.</p>
+				<code>modified_gmt</code>
+				</td>
+				<td>
+					<p>The date the revision was last modified, as GMT.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-parent">
 			<td>
-				<code>parent</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the parent of the revision.</p>
+				<code>parent</code>
+				</td>
+				<td>
+					<p>The ID for the parent of the revision.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>An alphanumeric identifier for the revision unique to its type.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>An alphanumeric identifier for the revision unique to its type.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object or string				</span>
-			</td>
-			<td>
-				<p>Title of template.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>Title of template.</p>
+					<p class="type">
+						JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object or string				</span>
-			</td>
-			<td>
-				<p>Content of template.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>Content of template.</p>
+					<p class="type">
+						JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_template_parts.md
+++ b/reference/wp_template_parts.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>ID of template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>ID of template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -23,44 +23,44 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>Unique slug identifying the template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Unique slug identifying the template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-theme">
 			<td>
 				<code>theme</code>
-				</td>
-				<td>
-					<p>Theme identifier for the template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Theme identifier for the template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>Type of template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type of template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-source">
 			<td>
 				<code>source</code>
-				</td>
-				<td>
-					<p>Source of template</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Source of template</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -68,11 +68,11 @@
 			<tr id="schema-origin">
 			<td>
 				<code>origin</code>
-				</td>
-				<td>
-					<p>Source of a customized template</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Source of a customized template</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -80,44 +80,44 @@
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>Content of template.</p>
-					<p class="type">
-						JSON data type: object or string				</p>
+			</td>
+			<td>
+				<p>Content of template.</p>
+				<p class="type">
+					JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>Title of template.</p>
-					<p class="type">
-						JSON data type: object or string				</p>
+			</td>
+			<td>
+				<p>Title of template.</p>
+				<p class="type">
+					JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>Description of template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Description of template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>Status of template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Status of template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
@@ -125,11 +125,11 @@
 			<tr id="schema-wp_id">
 			<td>
 				<code>wp_id</code>
-				</td>
-				<td>
-					<p>Post ID.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Post ID.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -137,11 +137,11 @@
 			<tr id="schema-has_theme_file">
 			<td>
 				<code>has_theme_file</code>
-				</td>
-				<td>
-					<p>Theme file exists.</p>
-					<p class="type">
-						JSON data type: bool				</p>
+			</td>
+			<td>
+				<p>Theme file exists.</p>
+				<p class="type">
+					JSON data type: bool				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -149,24 +149,24 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the template.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the template.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the template was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the template was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -174,11 +174,11 @@
 			<tr id="schema-area">
 			<td>
 				<code>area</code>
-				</td>
-				<td>
-					<p>Where the template part is intended for use (header, footer, etc.)</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Where the template part is intended for use (header, footer, etc.)</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_template_parts.md
+++ b/reference/wp_template_parts.md
@@ -10,161 +10,175 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>ID of template.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>ID of template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Unique slug identifying the template.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>Unique slug identifying the template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-theme">
 			<td>
-				<code>theme</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Theme identifier for the template.</p>
+				<code>theme</code>
+				</td>
+				<td>
+					<p>Theme identifier for the template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type of template.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>Type of template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-source">
 			<td>
-				<code>source</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Source of template</p>
+				<code>source</code>
+				</td>
+				<td>
+					<p>Source of template</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-origin">
 			<td>
-				<code>origin</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Source of a customized template</p>
+				<code>origin</code>
+				</td>
+				<td>
+					<p>Source of a customized template</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object or string				</span>
-			</td>
-			<td>
-				<p>Content of template.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>Content of template.</p>
+					<p class="type">
+						JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object or string				</span>
-			</td>
-			<td>
-				<p>Title of template.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>Title of template.</p>
+					<p class="type">
+						JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Description of template.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>Description of template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Status of template.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>Status of template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
 		</tr>
 			<tr id="schema-wp_id">
 			<td>
-				<code>wp_id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Post ID.</p>
+				<code>wp_id</code>
+				</td>
+				<td>
+					<p>Post ID.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-has_theme_file">
 			<td>
-				<code>has_theme_file</code><br />
-				<span class="type">
-					bool				</span>
-			</td>
-			<td>
-				<p>Theme file exists.</p>
+				<code>has_theme_file</code>
+				</td>
+				<td>
+					<p>Theme file exists.</p>
+					<p class="type">
+						JSON data type: bool				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the template.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the template.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
+							</td>
+		</tr>
+			<tr id="schema-modified">
+			<td>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the template was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
+									<p class="read-only">Read only</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-area">
 			<td>
-				<code>area</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Where the template part is intended for use (header, footer, etc.)</p>
+				<code>area</code>
+				</td>
+				<td>
+					<p>Where the template part is intended for use (header, footer, etc.)</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>

--- a/reference/wp_templates.md
+++ b/reference/wp_templates.md
@@ -10,161 +10,175 @@
 <table class="attributes">
 			<tr id="schema-id">
 			<td>
-				<code>id</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>ID of template.</p>
+				<code>id</code>
+				</td>
+				<td>
+					<p>ID of template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-slug">
 			<td>
-				<code>slug</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Unique slug identifying the template.</p>
+				<code>slug</code>
+				</td>
+				<td>
+					<p>Unique slug identifying the template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-theme">
 			<td>
-				<code>theme</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Theme identifier for the template.</p>
+				<code>theme</code>
+				</td>
+				<td>
+					<p>Theme identifier for the template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
-				<code>type</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Type of template.</p>
+				<code>type</code>
+				</td>
+				<td>
+					<p>Type of template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-source">
 			<td>
-				<code>source</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Source of template</p>
+				<code>source</code>
+				</td>
+				<td>
+					<p>Source of template</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-origin">
 			<td>
-				<code>origin</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Source of a customized template</p>
+				<code>origin</code>
+				</td>
+				<td>
+					<p>Source of a customized template</p>
+					<p class="type">
+						JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-content">
 			<td>
-				<code>content</code><br />
-				<span class="type">
-					object or string				</span>
-			</td>
-			<td>
-				<p>Content of template.</p>
+				<code>content</code>
+				</td>
+				<td>
+					<p>Content of template.</p>
+					<p class="type">
+						JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
-				<code>title</code><br />
-				<span class="type">
-					object or string				</span>
-			</td>
-			<td>
-				<p>Title of template.</p>
+				<code>title</code>
+				</td>
+				<td>
+					<p>Title of template.</p>
+					<p class="type">
+						JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
-				<code>description</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Description of template.</p>
+				<code>description</code>
+				</td>
+				<td>
+					<p>Description of template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
-				<code>status</code><br />
-				<span class="type">
-					string				</span>
-			</td>
-			<td>
-				<p>Status of template.</p>
+				<code>status</code>
+				</td>
+				<td>
+					<p>Status of template.</p>
+					<p class="type">
+						JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
 		</tr>
 			<tr id="schema-wp_id">
 			<td>
-				<code>wp_id</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>Post ID.</p>
+				<code>wp_id</code>
+				</td>
+				<td>
+					<p>Post ID.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-has_theme_file">
 			<td>
-				<code>has_theme_file</code><br />
-				<span class="type">
-					bool				</span>
-			</td>
-			<td>
-				<p>Theme file exists.</p>
+				<code>has_theme_file</code>
+				</td>
+				<td>
+					<p>Theme file exists.</p>
+					<p class="type">
+						JSON data type: bool				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-author">
 			<td>
-				<code>author</code><br />
-				<span class="type">
-					integer				</span>
-			</td>
-			<td>
-				<p>The ID for the author of the template.</p>
+				<code>author</code>
+				</td>
+				<td>
+					<p>The ID for the author of the template.</p>
+					<p class="type">
+						JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
+							</td>
+		</tr>
+			<tr id="schema-modified">
+			<td>
+				<code>modified</code>
+				</td>
+				<td>
+					<p>The date the template was last modified, in the site&#039;s timezone.</p>
+					<p class="type">
+						JSON data type: string,
+													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+										</p>
+									<p class="read-only">Read only</p>
+								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-is_custom">
 			<td>
-				<code>is_custom</code><br />
-				<span class="type">
-					bool				</span>
-			</td>
-			<td>
-				<p>Whether a template is a custom template.</p>
+				<code>is_custom</code>
+				</td>
+				<td>
+					<p>Whether a template is a custom template.</p>
+					<p class="type">
+						JSON data type: bool				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>

--- a/reference/wp_templates.md
+++ b/reference/wp_templates.md
@@ -11,11 +11,11 @@
 			<tr id="schema-id">
 			<td>
 				<code>id</code>
-				</td>
-				<td>
-					<p>ID of template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>ID of template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -23,44 +23,44 @@
 			<tr id="schema-slug">
 			<td>
 				<code>slug</code>
-				</td>
-				<td>
-					<p>Unique slug identifying the template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Unique slug identifying the template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-theme">
 			<td>
 				<code>theme</code>
-				</td>
-				<td>
-					<p>Theme identifier for the template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Theme identifier for the template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-type">
 			<td>
 				<code>type</code>
-				</td>
-				<td>
-					<p>Type of template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Type of template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-source">
 			<td>
 				<code>source</code>
-				</td>
-				<td>
-					<p>Source of template</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Source of template</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -68,11 +68,11 @@
 			<tr id="schema-origin">
 			<td>
 				<code>origin</code>
-				</td>
-				<td>
-					<p>Source of a customized template</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Source of a customized template</p>
+				<p class="type">
+					JSON data type: string				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -80,44 +80,44 @@
 			<tr id="schema-content">
 			<td>
 				<code>content</code>
-				</td>
-				<td>
-					<p>Content of template.</p>
-					<p class="type">
-						JSON data type: object or string				</p>
+			</td>
+			<td>
+				<p>Content of template.</p>
+				<p class="type">
+					JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-title">
 			<td>
 				<code>title</code>
-				</td>
-				<td>
-					<p>Title of template.</p>
-					<p class="type">
-						JSON data type: object or string				</p>
+			</td>
+			<td>
+				<p>Title of template.</p>
+				<p class="type">
+					JSON data type: object or string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-description">
 			<td>
 				<code>description</code>
-				</td>
-				<td>
-					<p>Description of template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Description of template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
 		</tr>
 			<tr id="schema-status">
 			<td>
 				<code>status</code>
-				</td>
-				<td>
-					<p>Status of template.</p>
-					<p class="type">
-						JSON data type: string				</p>
+			</td>
+			<td>
+				<p>Status of template.</p>
+				<p class="type">
+					JSON data type: string				</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 									<p>One of: <code>publish</code>, <code>future</code>, <code>draft</code>, <code>pending</code>, <code>private</code></p>
 							</td>
@@ -125,11 +125,11 @@
 			<tr id="schema-wp_id">
 			<td>
 				<code>wp_id</code>
-				</td>
-				<td>
-					<p>Post ID.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>Post ID.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -137,11 +137,11 @@
 			<tr id="schema-has_theme_file">
 			<td>
 				<code>has_theme_file</code>
-				</td>
-				<td>
-					<p>Theme file exists.</p>
-					<p class="type">
-						JSON data type: bool				</p>
+			</td>
+			<td>
+				<p>Theme file exists.</p>
+				<p class="type">
+					JSON data type: bool				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>
@@ -149,24 +149,24 @@
 			<tr id="schema-author">
 			<td>
 				<code>author</code>
-				</td>
-				<td>
-					<p>The ID for the author of the template.</p>
-					<p class="type">
-						JSON data type: integer				</p>
+			</td>
+			<td>
+				<p>The ID for the author of the template.</p>
+				<p class="type">
+					JSON data type: integer				</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code>, <code>embed</code></p>
 							</td>
 		</tr>
 			<tr id="schema-modified">
 			<td>
 				<code>modified</code>
-				</td>
-				<td>
-					<p>The date the template was last modified, in the site&#039;s timezone.</p>
-					<p class="type">
-						JSON data type: string,
-													Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
-										</p>
+			</td>
+			<td>
+				<p>The date the template was last modified, in the site&#039;s timezone.</p>
+				<p class="type">
+					JSON data type: string,
+											Format: datetime (<a href="https://core.trac.wordpress.org/ticket/41032">details</a>)
+									</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>view</code>, <code>edit</code></p>
 							</td>
@@ -174,11 +174,11 @@
 			<tr id="schema-is_custom">
 			<td>
 				<code>is_custom</code>
-				</td>
-				<td>
-					<p>Whether a template is a custom template.</p>
-					<p class="type">
-						JSON data type: bool				</p>
+			</td>
+			<td>
+				<p>Whether a template is a custom template.</p>
+				<p class="type">
+					JSON data type: bool				</p>
 									<p class="read-only">Read only</p>
 								<p class="context">Context: <code>embed</code>, <code>view</code>, <code>edit</code></p>
 							</td>


### PR DESCRIPTION
As discussed with @kadamwhite and @addisonhardy at WordCamp US 2023 Contributor Day.

Aside from moving the information to the right column, it also adds a "JSON data type:" label to clarify that it is not referencing PHP data types, and a "Format:" label for the format information.

