### PR TITLE
Fix typo in `prefix_data_arg_sanitize_callback` doc in Routes and Endpoints page

### DIFF
--- a/extending-the-rest-api/routes-and-endpoints.md
+++ b/extending-the-rest-api/routes-and-endpoints.md
@@ -516,7 +516,7 @@ function prefix_data_arg_validate_callback( $value, $request, $param ) {
  * @param  mixed            $value   Value of the 'filter' argument.
  * @param  WP_REST_Request  $request The current request object.
  * @param  string           $param   Key of the parameter. In this case it is 'filter'.
- * @return WP_Error|boolean
+ * @return string
  */
 function prefix_data_arg_sanitize_callback( $value, $request, $param ) {
     // It is as simple as returning the sanitized value.


### PR DESCRIPTION
This PR fixes the tag `@return` since the return of the function `prefix_data_arg_sanitize_callback` is a string: `return sanitize_text_field( $value );`