### PR TITLE
Update adding-custom-endpoints.md to note permalink structure

### DIFF
--- a/extending-the-rest-api/adding-custom-endpoints.md
+++ b/extending-the-rest-api/adding-custom-endpoints.md
@@ -49,6 +49,10 @@ Right now, we're only registering the one endpoint for the route. The term "rout
 
 For example, if your site domain is `example.com` and you've kept the API path of `wp-json`, then the full URL would be `http://example.com/wp-json/myplugin/v1/author/(?P\d+)`.
 
+[alert]
+On sites without pretty permalinks, the route is instead added to the URL as the `rest_route` parameter. For the above example, the full URL would then be <code>http://example.com/?rest_route=/myplugin/v1/author/(?P\d+)</code>
+[/alert]
+
 Each route can have any number of endpoints, and for each endpoint, you can define the HTTP methods allowed, a callback function for responding to the request and a permissions callback for creating custom permissions. In addition you can define allowed fields in the request and for each field specify a default value, a sanitization callback, a validation callback, and whether the field is required.
 
 


### PR DESCRIPTION
The provided example does not work with a fresh WordPress instance, as it does not make use of "pretty permalinks" (which is a very vague description).

On [a later page](https://developer.wordpress.org/rest-api/extending-the-rest-api/routes-and-endpoints/) an alert with this information is given. But on this page, this fact is not mentioned.
It is very confusing to land on this page, copy the example and get a 404 without any information.
One would assume the permalink structure does not affect internal routes like `/wp-json` as it does not change `/wp-admin` i.e.


See https://stackoverflow.com/questions/34670533/wordpress-rest-api-wp-api-404-error-cannot-access-the-wordpress-rest-api and similar questions