### PR TITLE
Fixes backbone featured_media property name

### DIFF
--- a/using-the-rest-api/backbone-javascript-client.md
+++ b/using-the-rest-api/backbone-javascript-client.md
@@ -69,7 +69,7 @@ Each model and collection includes a reference to its default values, for exampl
 * date: null
 * date_gmt: null
 * excerpt: null
-* featured_image: null
+* featured_media: null
 * format: null
 * modified: null
 * modified_gmt: null


### PR DESCRIPTION
The documentation claims that `featured_image` is the featured image property in backbone, but it's actually `featured_media`.